### PR TITLE
[jin.100] 방탈출 예약 관리 1, 2단계

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+## 상황 설명
+
+### 1단계
+- 기존에는 로컬 환경에서 콘솔 애플리케이션을 이용하여 예약 정보를 관리해왔다.
+- 콘솔 애플리케이션을 웹 애플리케이션으로 전환하여 집에서도 웹을 통해 예약 관리를 할 수 있도록 해야한다.
+
+### 2단계
+- 기존에는 별도의 저장공간을 활용하지 않아 애플리케이션을 종료할 경우 데이터가 사라졌다.
+- 데이터베이스를 연동하여 애플리케이션 재부팅 하더라도 데이터가 남아있도록 한다.
+
+## 프로그래밍 요구사항
+
+### 1단계
+- 기존 콘솔 애플리케이션은 그대로 잘 동작해야한다.
+- 콘솔 애플리케이션과 웹 애플리케이션의 중복 코드는 허용한다. (다음 단계에서 리팩터링 예정)
+
+### 2단계
+- 콘솔 애플리케이션과 웹 애플리케이션에서 각각 데이터베이스에 접근하는 로직을 구현한다.
+- 콘솔 애플리케이션에서 데이터베이스에 접근 시 `JdbcTemplate`를 사용하지 않는다. 직접 `Connection`을 생성하여 데이터베이스에 접근한다.
+- 웹 애플리케이션에서 데이터베이스 접근 시 `JdbcTemplate`를 사용한다.
+- 콘솔 애플리케이션과 웹 애플리케이션의 중복 코드 제거해본다.
+## API 설계
+
+### 예약 생성
+```http request
+POST /reservations HTTP/1.1
+content-type: application/json; charset=UTF-8
+host: localhost:8080
+
+{
+    "date": "2022-08-11",
+    "time": "13:00",
+    "name": "name"
+}
+```
+```http request
+HTTP/1.1 201 Created
+Location: /reservations/1
+```
+
+### 예약 조회
+```http request
+GET /reservations/1 HTTP/1.1
+```
+```http request
+HTTP/1.1 200 
+Content-Type: application/json
+
+{
+    "id": 1,
+    "date": "2022-08-11",
+    "time": "13:00",
+    "name": "name",
+    "themeName": "워너고홈",
+    "themeDesc": "병맛 어드벤처 회사 코믹물",
+    "themePrice": 29000
+}
+```
+
+### 예약 삭제
+```http request
+DELETE /reservations/1 HTTP/1.1
+```
+```http request
+HTTP/1.1 204 
+```

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ java {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    runtimeOnly 'com.h2database:h2'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 plugins {
+    id 'org.springframework.boot' version '2.7.2'
+    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
 }
 
@@ -13,6 +15,10 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(11)
     }
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ java {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
 }
 
 test {

--- a/src/main/java/nextstep/Reservation.java
+++ b/src/main/java/nextstep/Reservation.java
@@ -23,6 +23,10 @@ public class Reservation {
         this(null, date, time, name, theme);
     }
 
+    public boolean hasSameDateTime(Reservation other) {
+        return Objects.equals(date, other.date) && Objects.equals(time, other.time);
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/nextstep/Reservation.java
+++ b/src/main/java/nextstep/Reservation.java
@@ -1,5 +1,7 @@
 package nextstep;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Objects;
@@ -11,7 +13,7 @@ public class Reservation {
     private final String name;
     private final Theme theme;
 
-    public Reservation(Long id, LocalDate date, LocalTime time, String name, Theme theme) {
+    private Reservation(Long id, LocalDate date, LocalTime time, String name, Theme theme) {
         this.id = id;
         this.date = date;
         this.time = time;
@@ -19,8 +21,26 @@ public class Reservation {
         this.theme = theme;
     }
 
-    public Reservation(LocalDate date, LocalTime time, String name, Theme theme) {
-        this(null, date, time, name, theme);
+    public static Reservation of(Long id, LocalDate date, LocalTime time, String name, Theme theme) {
+        return new Reservation(id, date, time, name, theme);
+    }
+
+    public static Reservation of(LocalDate date, LocalTime time, String name, Theme theme) {
+        return new Reservation(null, date, time, name, theme);
+    }
+
+    public static Reservation fromResultSet(ResultSet resultSet) throws SQLException {
+        return new Reservation(
+                resultSet.getLong("id"),
+                resultSet.getDate("date").toLocalDate(),
+                resultSet.getTime("time").toLocalTime(),
+                resultSet.getString("name"),
+                Theme.of(
+                        resultSet.getString("theme_name"),
+                        resultSet.getString("theme_desc"),
+                        resultSet.getInt("theme_price")
+                )
+        );
     }
 
     public boolean isAtDateTime(LocalDate date, LocalTime time) {

--- a/src/main/java/nextstep/Reservation.java
+++ b/src/main/java/nextstep/Reservation.java
@@ -2,13 +2,14 @@ package nextstep;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Objects;
 
 public class Reservation {
     private Long id;
-    private LocalDate date;
-    private LocalTime time;
-    private String name;
-    private Theme theme;
+    private final LocalDate date;
+    private final LocalTime time;
+    private final String name;
+    private final Theme theme;
 
     public Reservation(Long id, LocalDate date, LocalTime time, String name, Theme theme) {
         this.id = id;
@@ -18,8 +19,16 @@ public class Reservation {
         this.theme = theme;
     }
 
+    public Reservation(LocalDate date, LocalTime time, String name, Theme theme) {
+        this(null, date, time, name, theme);
+    }
+
     public Long getId() {
         return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
     }
 
     public LocalDate getDate() {
@@ -36,5 +45,18 @@ public class Reservation {
 
     public Theme getTheme() {
         return theme;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Reservation that = (Reservation) o;
+        return Objects.equals(id, that.id) && Objects.equals(date, that.date) && Objects.equals(time, that.time) && Objects.equals(name, that.name) && Objects.equals(theme, that.theme);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, date, time, name, theme);
     }
 }

--- a/src/main/java/nextstep/Reservation.java
+++ b/src/main/java/nextstep/Reservation.java
@@ -1,7 +1,5 @@
 package nextstep;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Objects;
@@ -29,19 +27,7 @@ public class Reservation {
         return new Reservation(null, date, time, name, theme);
     }
 
-    public static Reservation fromResultSet(ResultSet resultSet) throws SQLException {
-        return new Reservation(
-                resultSet.getLong("id"),
-                resultSet.getDate("date").toLocalDate(),
-                resultSet.getTime("time").toLocalTime(),
-                resultSet.getString("name"),
-                Theme.of(
-                        resultSet.getString("theme_name"),
-                        resultSet.getString("theme_desc"),
-                        resultSet.getInt("theme_price")
-                )
-        );
-    }
+
 
     public boolean isAtDateTime(LocalDate date, LocalTime time) {
         return Objects.equals(this.date, date) && Objects.equals(this.time, time);

--- a/src/main/java/nextstep/Reservation.java
+++ b/src/main/java/nextstep/Reservation.java
@@ -23,8 +23,8 @@ public class Reservation {
         this(null, date, time, name, theme);
     }
 
-    public boolean hasSameDateTime(Reservation other) {
-        return Objects.equals(date, other.date) && Objects.equals(time, other.time);
+    public boolean isAtDateTime(LocalDate date, LocalTime time) {
+        return Objects.equals(this.date, date) && Objects.equals(this.time, time);
     }
 
     public Long getId() {

--- a/src/main/java/nextstep/RoomEscapeApplication.java
+++ b/src/main/java/nextstep/RoomEscapeApplication.java
@@ -1,6 +1,7 @@
 package nextstep;
 
 import nextstep.dto.request.CreateReservationRequest;
+import nextstep.dto.response.ReservationResponse;
 import nextstep.exception.DuplicateReservationException;
 import nextstep.exception.ReservationNotFoundException;
 import nextstep.repository.ReservationH2Repository;
@@ -20,7 +21,6 @@ public class RoomEscapeApplication {
         ReservationRepository repository = new ReservationH2Repository();
         RoomEscapeService roomEscapeService = new RoomEscapeService(repository);
 
-
         while (true) {
             System.out.println();
             System.out.println("### 명령어를 입력하세요. ###");
@@ -38,7 +38,7 @@ public class RoomEscapeApplication {
                 String name = params.split(",")[2];
 
                 try {
-                    Reservation reservation = roomEscapeService.add(new CreateReservationRequest(date, time, name));
+                    ReservationResponse reservation = roomEscapeService.add(CreateReservationRequest.of(date, time, name));
                     System.out.println("예약이 등록되었습니다.");
                     System.out.println("예약 번호: " + reservation.getId());
                     System.out.println("예약 날짜: " + reservation.getDate());
@@ -57,15 +57,15 @@ public class RoomEscapeApplication {
                 Long id = Long.parseLong(params.split(",")[0]);
 
                 try {
-                    Reservation reservation = roomEscapeService.get(id);
+                    ReservationResponse reservation = roomEscapeService.get(id);
 
                     System.out.println("예약 번호: " + reservation.getId());
                     System.out.println("예약 날짜: " + reservation.getDate());
                     System.out.println("예약 시간: " + reservation.getTime());
                     System.out.println("예약자 이름: " + reservation.getName());
-                    System.out.println("예약 테마 이름: " + reservation.getTheme().getName());
-                    System.out.println("예약 테마 설명: " + reservation.getTheme().getDesc());
-                    System.out.println("예약 테마 가격: " + reservation.getTheme().getPrice());
+                    System.out.println("예약 테마 이름: " + reservation.getThemeName());
+                    System.out.println("예약 테마 설명: " + reservation.getThemeDesc());
+                    System.out.println("예약 테마 가격: " + reservation.getThemePrice());
                 } catch (ReservationNotFoundException e) {
                     System.out.println(e.getMessage());
                 }

--- a/src/main/java/nextstep/RoomEscapeApplication.java
+++ b/src/main/java/nextstep/RoomEscapeApplication.java
@@ -1,7 +1,7 @@
 package nextstep;
 
 import nextstep.dto.request.CreateReservationRequest;
-import nextstep.dto.response.ReservationResponse;
+import nextstep.dto.response.ReservationConsoleResponse;
 import nextstep.exception.DatabaseException;
 import nextstep.exception.DuplicateReservationException;
 import nextstep.exception.ReservationNotFoundException;
@@ -39,15 +39,13 @@ public class RoomEscapeApplication {
                 String name = params.split(",")[2];
 
                 try {
-                    ReservationResponse reservation = roomEscapeService.add(CreateReservationRequest.of(date, time, name));
+                    ReservationConsoleResponse reservation = roomEscapeService.createReservationForConsole(CreateReservationRequest.of(date, time, name));
                     System.out.println("예약이 등록되었습니다.");
                     System.out.println("예약 번호: " + reservation.getId());
                     System.out.println("예약 날짜: " + reservation.getDate());
                     System.out.println("예약 시간: " + reservation.getTime());
                     System.out.println("예약자 이름: " + reservation.getName());
-                } catch (DuplicateReservationException e) {
-                    System.out.println(e.getMessage());
-                } catch (DatabaseException e) {
+                } catch (DuplicateReservationException | DatabaseException e) {
                     System.out.println(e.getMessage());
                 }
 
@@ -60,7 +58,7 @@ public class RoomEscapeApplication {
                 Long id = Long.parseLong(params.split(",")[0]);
 
                 try {
-                    ReservationResponse reservation = roomEscapeService.get(id);
+                    ReservationConsoleResponse reservation = roomEscapeService.findReservationForConsole(id);
 
                     System.out.println("예약 번호: " + reservation.getId());
                     System.out.println("예약 날짜: " + reservation.getDate());
@@ -69,9 +67,7 @@ public class RoomEscapeApplication {
                     System.out.println("예약 테마 이름: " + reservation.getThemeName());
                     System.out.println("예약 테마 설명: " + reservation.getThemeDesc());
                     System.out.println("예약 테마 가격: " + reservation.getThemePrice());
-                } catch (ReservationNotFoundException e) {
-                    System.out.println(e.getMessage());
-                } catch (DatabaseException e) {
+                } catch (ReservationNotFoundException | DatabaseException e) {
                     System.out.println(e.getMessage());
                 }
             }
@@ -82,7 +78,7 @@ public class RoomEscapeApplication {
                 Long id = Long.parseLong(params.split(",")[0]);
 
                 try {
-                    roomEscapeService.delete(id);
+                    roomEscapeService.cancelReservation(id);
                     System.out.println("예약이 취소되었습니다.");
                 } catch (DatabaseException e) {
                     System.out.println(e.getMessage());

--- a/src/main/java/nextstep/RoomEscapeApplication.java
+++ b/src/main/java/nextstep/RoomEscapeApplication.java
@@ -2,6 +2,7 @@ package nextstep;
 
 import nextstep.dto.request.CreateReservationRequest;
 import nextstep.dto.response.ReservationResponse;
+import nextstep.exception.DatabaseException;
 import nextstep.exception.DuplicateReservationException;
 import nextstep.exception.ReservationNotFoundException;
 import nextstep.repository.ReservationH2Repository;
@@ -46,6 +47,8 @@ public class RoomEscapeApplication {
                     System.out.println("예약자 이름: " + reservation.getName());
                 } catch (DuplicateReservationException e) {
                     System.out.println(e.getMessage());
+                } catch (DatabaseException e) {
+                    System.out.println(e.getMessage());
                 }
 
 
@@ -68,6 +71,8 @@ public class RoomEscapeApplication {
                     System.out.println("예약 테마 가격: " + reservation.getThemePrice());
                 } catch (ReservationNotFoundException e) {
                     System.out.println(e.getMessage());
+                } catch (DatabaseException e) {
+                    System.out.println(e.getMessage());
                 }
             }
 
@@ -76,9 +81,12 @@ public class RoomEscapeApplication {
 
                 Long id = Long.parseLong(params.split(",")[0]);
 
-                roomEscapeService.delete(id);
-
-                System.out.println("예약이 취소되었습니다.");
+                try {
+                    roomEscapeService.delete(id);
+                    System.out.println("예약이 취소되었습니다.");
+                } catch (DatabaseException e) {
+                    System.out.println(e.getMessage());
+                }
             }
 
             if (input.equals(QUIT)) {

--- a/src/main/java/nextstep/RoomEscapeApplication.java
+++ b/src/main/java/nextstep/RoomEscapeApplication.java
@@ -1,14 +1,11 @@
 package nextstep;
 
-import nextstep.dto.CreateReservationRequest;
+import nextstep.dto.request.CreateReservationRequest;
 import nextstep.exception.DuplicateReservationException;
 import nextstep.exception.ReservationNotFoundException;
 import nextstep.repository.ReservationH2Repository;
 import nextstep.repository.ReservationRepository;
 import nextstep.service.RoomEscapeService;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.Scanner;
 
 public class RoomEscapeApplication {

--- a/src/main/java/nextstep/RoomEscapeApplication.java
+++ b/src/main/java/nextstep/RoomEscapeApplication.java
@@ -1,5 +1,7 @@
 package nextstep;
 
+import nextstep.repository.ReservationH2Repository;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -13,10 +15,10 @@ public class RoomEscapeApplication {
     private static final String DELETE = "delete";
     private static final String QUIT = "quit";
 
+
     public static void main(String[] args) {
         Scanner scanner = new Scanner(System.in);
-        List<Reservation> reservations = new ArrayList<>();
-        Long reservationIdIndex = 0L;
+        ReservationH2Repository repository = new ReservationH2Repository();
 
         Theme theme = new Theme("워너고홈", "병맛 어드벤처 회사 코믹물", 29_000);
 
@@ -37,14 +39,13 @@ public class RoomEscapeApplication {
                 String name = params.split(",")[2];
 
                 Reservation reservation = new Reservation(
-                        ++reservationIdIndex,
                         LocalDate.parse(date),
                         LocalTime.parse(time + ":00"),
                         name,
                         theme
                 );
 
-                reservations.add(reservation);
+                repository.add(reservation);
 
                 System.out.println("예약이 등록되었습니다.");
                 System.out.println("예약 번호: " + reservation.getId());
@@ -58,10 +59,7 @@ public class RoomEscapeApplication {
 
                 Long id = Long.parseLong(params.split(",")[0]);
 
-                Reservation reservation = reservations.stream()
-                        .filter(it -> Objects.equals(it.getId(), id))
-                        .findFirst()
-                        .orElseThrow(RuntimeException::new);
+                Reservation reservation = repository.get(id);
 
                 System.out.println("예약 번호: " + reservation.getId());
                 System.out.println("예약 날짜: " + reservation.getDate());
@@ -77,9 +75,8 @@ public class RoomEscapeApplication {
 
                 Long id = Long.parseLong(params.split(",")[0]);
 
-                if (reservations.removeIf(it -> Objects.equals(it.getId(), id))) {
-                    System.out.println("예약이 취소되었습니다.");
-                }
+                repository.delete(id);
+                System.out.println("예약이 취소되었습니다.");
             }
 
             if (input.equals(QUIT)) {

--- a/src/main/java/nextstep/RoomEscapeSpringApplication.java
+++ b/src/main/java/nextstep/RoomEscapeSpringApplication.java
@@ -1,0 +1,12 @@
+package nextstep;
+
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class RoomEscapeSpringApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(RoomEscapeSpringApplication.class, args);
+    }
+}

--- a/src/main/java/nextstep/Theme.java
+++ b/src/main/java/nextstep/Theme.java
@@ -1,6 +1,7 @@
 package nextstep;
 
 public class Theme {
+    public static final Theme DEFAULT_THEME = Theme.of("워너고홈", "병맛 어드벤처 회사 코믹물", 29_000);
     private final String name;
     private final String desc;
     private final Integer price;

--- a/src/main/java/nextstep/Theme.java
+++ b/src/main/java/nextstep/Theme.java
@@ -1,14 +1,18 @@
 package nextstep;
 
 public class Theme {
-    private String name;
-    private String desc;
-    private Integer price;
+    private final String name;
+    private final String desc;
+    private final Integer price;
 
-    public Theme(String name, String desc, Integer price) {
+    private Theme(String name, String desc, Integer price) {
         this.name = name;
         this.desc = desc;
         this.price = price;
+    }
+
+    public static Theme of(String name, String desc, Integer price) {
+        return new Theme(name, desc, price);
     }
 
     public String getName() {

--- a/src/main/java/nextstep/controller/RoomEscapeController.java
+++ b/src/main/java/nextstep/controller/RoomEscapeController.java
@@ -1,7 +1,8 @@
 package nextstep.controller;
 
 import nextstep.Reservation;
-import nextstep.dto.CreateReservationRequest;
+import nextstep.dto.request.CreateReservationRequest;
+import nextstep.dto.response.ReservationResponse;
 import nextstep.service.RoomEscapeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -20,18 +21,18 @@ public class RoomEscapeController {
     }
 
     @PostMapping("")
-    public ResponseEntity<Reservation> createReservation(@RequestBody CreateReservationRequest createReservationRequest) {
+    public ResponseEntity<ReservationResponse> createReservation(@RequestBody CreateReservationRequest createReservationRequest) {
         Reservation reservation = roomEscapeService.add(createReservationRequest);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .header("Location", "/reservations/" + reservation.getId())
-                .body(reservation);
+                .body(ReservationResponse.fromEntity(reservation));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Reservation> findReservation(@PathVariable Long id) {
+    public ResponseEntity<ReservationResponse> findReservation(@PathVariable Long id) {
         return ResponseEntity
-                .ok(roomEscapeService.get(id));
+                .ok(ReservationResponse.fromEntity(roomEscapeService.get(id)));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/nextstep/controller/RoomEscapeController.java
+++ b/src/main/java/nextstep/controller/RoomEscapeController.java
@@ -3,6 +3,8 @@ package nextstep.controller;
 import nextstep.Reservation;
 import nextstep.dto.request.CreateReservationRequest;
 import nextstep.dto.response.ReservationResponse;
+import nextstep.exception.DuplicateReservationException;
+import nextstep.exception.ReservationNotFoundException;
 import nextstep.service.RoomEscapeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -21,7 +23,8 @@ public class RoomEscapeController {
     }
 
     @PostMapping("")
-    public ResponseEntity<ReservationResponse> createReservation(@RequestBody CreateReservationRequest createReservationRequest) {
+    public ResponseEntity<ReservationResponse> createReservation(
+            @RequestBody CreateReservationRequest createReservationRequest) throws DuplicateReservationException {
         Reservation reservation = roomEscapeService.add(createReservationRequest);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
@@ -30,7 +33,7 @@ public class RoomEscapeController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ReservationResponse> findReservation(@PathVariable Long id) {
+    public ResponseEntity<ReservationResponse> findReservation(@PathVariable Long id) throws ReservationNotFoundException {
         return ResponseEntity
                 .ok(ReservationResponse.fromEntity(roomEscapeService.get(id)));
     }

--- a/src/main/java/nextstep/controller/RoomEscapeController.java
+++ b/src/main/java/nextstep/controller/RoomEscapeController.java
@@ -6,9 +6,7 @@ import nextstep.service.RoomEscapeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController("/reservations")
 public class RoomEscapeController {
@@ -27,5 +25,11 @@ public class RoomEscapeController {
                 .status(HttpStatus.CREATED)
                 .header("Location", "/reservations/" + reservation.getId())
                 .body(reservation);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Reservation> findReservation(@PathVariable Long id) {
+        return ResponseEntity
+                .ok(roomEscapeService.get(id));
     }
 }

--- a/src/main/java/nextstep/controller/RoomEscapeController.java
+++ b/src/main/java/nextstep/controller/RoomEscapeController.java
@@ -1,6 +1,5 @@
 package nextstep.controller;
 
-import nextstep.Reservation;
 import nextstep.dto.request.CreateReservationRequest;
 import nextstep.dto.response.ReservationResponse;
 import nextstep.exception.DuplicateReservationException;
@@ -25,17 +24,17 @@ public class RoomEscapeController {
     @PostMapping("")
     public ResponseEntity<ReservationResponse> createReservation(
             @RequestBody CreateReservationRequest createReservationRequest) throws DuplicateReservationException {
-        Reservation reservation = roomEscapeService.add(createReservationRequest);
+        ReservationResponse reservationResponse = roomEscapeService.add(createReservationRequest);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .header("Location", "/reservations/" + reservation.getId())
-                .body(ReservationResponse.fromEntity(reservation));
+                .header("Location", "/reservations/" + reservationResponse.getId())
+                .body(reservationResponse);
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<ReservationResponse> findReservation(@PathVariable Long id) throws ReservationNotFoundException {
         return ResponseEntity
-                .ok(ReservationResponse.fromEntity(roomEscapeService.get(id)));
+                .ok(roomEscapeService.get(id));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/nextstep/controller/RoomEscapeController.java
+++ b/src/main/java/nextstep/controller/RoomEscapeController.java
@@ -4,6 +4,8 @@ import nextstep.Reservation;
 import nextstep.dto.CreateReservationRequest;
 import nextstep.service.RoomEscapeService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,7 +21,11 @@ public class RoomEscapeController {
     }
 
     @PostMapping("")
-    public Reservation createReservation(@RequestBody CreateReservationRequest createReservationRequest) {
-        return roomEscapeService.add(createReservationRequest);
+    public ResponseEntity<Reservation> createReservation(@RequestBody CreateReservationRequest createReservationRequest) {
+        Reservation reservation = roomEscapeService.add(createReservationRequest);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .header("Location", "/reservations/" + reservation.getId())
+                .body(reservation);
     }
 }

--- a/src/main/java/nextstep/controller/RoomEscapeController.java
+++ b/src/main/java/nextstep/controller/RoomEscapeController.java
@@ -5,7 +5,6 @@ import nextstep.dto.response.ReservationResponse;
 import nextstep.exception.DuplicateReservationException;
 import nextstep.exception.ReservationNotFoundException;
 import nextstep.service.RoomEscapeService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,7 +15,6 @@ public class RoomEscapeController {
 
     private final RoomEscapeService roomEscapeService;
 
-    @Autowired
     public RoomEscapeController(RoomEscapeService roomEscapeService) {
         this.roomEscapeService = roomEscapeService;
     }

--- a/src/main/java/nextstep/controller/RoomEscapeController.java
+++ b/src/main/java/nextstep/controller/RoomEscapeController.java
@@ -1,0 +1,25 @@
+package nextstep.controller;
+
+import nextstep.Reservation;
+import nextstep.dto.CreateReservationRequest;
+import nextstep.service.RoomEscapeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("/reservations")
+public class RoomEscapeController {
+
+    private final RoomEscapeService roomEscapeService;
+
+    @Autowired
+    public RoomEscapeController(RoomEscapeService roomEscapeService) {
+        this.roomEscapeService = roomEscapeService;
+    }
+
+    @PostMapping("")
+    public Reservation createReservation(@RequestBody CreateReservationRequest createReservationRequest) {
+        return roomEscapeService.add(createReservationRequest);
+    }
+}

--- a/src/main/java/nextstep/controller/RoomEscapeController.java
+++ b/src/main/java/nextstep/controller/RoomEscapeController.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@RestController("/reservations")
+@RequestMapping("/reservations")
+@RestController
 public class RoomEscapeController {
 
     private final RoomEscapeService roomEscapeService;

--- a/src/main/java/nextstep/controller/RoomEscapeController.java
+++ b/src/main/java/nextstep/controller/RoomEscapeController.java
@@ -22,7 +22,7 @@ public class RoomEscapeController {
     @PostMapping("")
     public ResponseEntity<ReservationResponse> createReservation(
             @RequestBody CreateReservationRequest createReservationRequest) throws DuplicateReservationException {
-        ReservationResponse reservationResponse = roomEscapeService.add(createReservationRequest);
+        ReservationResponse reservationResponse = roomEscapeService.createReservationForWeb(createReservationRequest);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .header("Location", "/reservations/" + reservationResponse.getId())
@@ -32,12 +32,12 @@ public class RoomEscapeController {
     @GetMapping("/{id}")
     public ResponseEntity<ReservationResponse> findReservation(@PathVariable Long id) throws ReservationNotFoundException {
         return ResponseEntity
-                .ok(roomEscapeService.get(id));
+                .ok(roomEscapeService.findReservationForWeb(id));
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteReservation(@PathVariable Long id) {
-        roomEscapeService.delete(id);
+        roomEscapeService.cancelReservation(id);
 
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)

--- a/src/main/java/nextstep/controller/RoomEscapeController.java
+++ b/src/main/java/nextstep/controller/RoomEscapeController.java
@@ -32,4 +32,13 @@ public class RoomEscapeController {
         return ResponseEntity
                 .ok(roomEscapeService.get(id));
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteReservation(@PathVariable Long id) {
+        roomEscapeService.delete(id);
+
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
+    }
 }

--- a/src/main/java/nextstep/controller/RoomEscapeControllerAdvice.java
+++ b/src/main/java/nextstep/controller/RoomEscapeControllerAdvice.java
@@ -1,6 +1,7 @@
 package nextstep.controller;
 
 import nextstep.exception.DuplicateReservationException;
+import nextstep.exception.ReservationNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -11,6 +12,13 @@ public class RoomEscapeControllerAdvice {
 
     @ExceptionHandler(DuplicateReservationException.class)
     public ResponseEntity<String> handleDuplicateReservationException(DuplicateReservationException exception) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(exception.getMessage());
+    }
+
+    @ExceptionHandler(ReservationNotFoundException.class)
+    public ResponseEntity<String> handleReservationNotFoundException(ReservationNotFoundException exception) {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(exception.getMessage());

--- a/src/main/java/nextstep/controller/RoomEscapeControllerAdvice.java
+++ b/src/main/java/nextstep/controller/RoomEscapeControllerAdvice.java
@@ -1,0 +1,18 @@
+package nextstep.controller;
+
+import nextstep.exception.DuplicateReservationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class RoomEscapeControllerAdvice {
+
+    @ExceptionHandler(DuplicateReservationException.class)
+    public ResponseEntity<String> handleDuplicateReservationException(DuplicateReservationException exception) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(exception.getMessage());
+    }
+}

--- a/src/main/java/nextstep/dto/CreateReservationRequest.java
+++ b/src/main/java/nextstep/dto/CreateReservationRequest.java
@@ -1,0 +1,24 @@
+package nextstep.dto;
+
+public class CreateReservationRequest {
+    private final String date;
+    private final String time;
+    private final String name;
+
+    public CreateReservationRequest(String date, String time, String name) {
+        this.date = date;
+        this.time = time;
+        this.name = name;
+    }
+
+    public String getDate() {
+        return date;
+    }
+    public String getTime() {
+        return time;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/nextstep/dto/request/CreateReservationRequest.java
+++ b/src/main/java/nextstep/dto/request/CreateReservationRequest.java
@@ -1,5 +1,8 @@
 package nextstep.dto.request;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+
 public class CreateReservationRequest {
     private final String date;
     private final String time;
@@ -11,11 +14,12 @@ public class CreateReservationRequest {
         this.name = name;
     }
 
-    public String getDate() {
-        return date;
+    public LocalDate getDate() {
+        return LocalDate.parse(date);
     }
-    public String getTime() {
-        return time;
+
+    public LocalTime getTime() {
+        return LocalTime.parse(time + ":00");
     }
 
     public String getName() {

--- a/src/main/java/nextstep/dto/request/CreateReservationRequest.java
+++ b/src/main/java/nextstep/dto/request/CreateReservationRequest.java
@@ -1,5 +1,8 @@
 package nextstep.dto.request;
 
+import nextstep.Reservation;
+import nextstep.Theme;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 
@@ -8,10 +11,18 @@ public class CreateReservationRequest {
     private final String time;
     private final String name;
 
-    public CreateReservationRequest(String date, String time, String name) {
+    private CreateReservationRequest(String date, String time, String name) {
         this.date = date;
         this.time = time;
         this.name = name;
+    }
+
+    public static CreateReservationRequest of(String date, String time, String name) {
+        return new CreateReservationRequest(date, time, name);
+    }
+
+    public Reservation toEntity() {
+        return Reservation.of(LocalDate.parse(date), LocalTime.parse(time + ":00"), name, Theme.DEFAULT_THEME);
     }
 
     public LocalDate getDate() {

--- a/src/main/java/nextstep/dto/request/CreateReservationRequest.java
+++ b/src/main/java/nextstep/dto/request/CreateReservationRequest.java
@@ -1,4 +1,4 @@
-package nextstep.dto;
+package nextstep.dto.request;
 
 public class CreateReservationRequest {
     private final String date;

--- a/src/main/java/nextstep/dto/response/ReservationConsoleResponse.java
+++ b/src/main/java/nextstep/dto/response/ReservationConsoleResponse.java
@@ -1,0 +1,64 @@
+package nextstep.dto.response;
+
+import nextstep.Reservation;
+
+public class ReservationConsoleResponse {
+
+    private final Long id;
+    private final String date;
+    private final String time;
+    private final String name;
+    private final String themeName;
+    private final String themeDesc;
+    private final Integer themePrice;
+
+    private ReservationConsoleResponse(Long id, String date, String time, String name, String themeName, String themeDesc, Integer themePrice) {
+        this.id = id;
+        this.date = date;
+        this.time = time;
+        this.name = name;
+        this.themeName = themeName;
+        this.themeDesc = themeDesc;
+        this.themePrice = themePrice;
+    }
+
+    public static ReservationConsoleResponse fromEntity(Reservation reservation) {
+        return new ReservationConsoleResponse(
+                reservation.getId(),
+                reservation.getDate().toString(),
+                reservation.getTime().toString(),
+                reservation.getName(),
+                reservation.getTheme().getName(),
+                reservation.getTheme().getDesc(),
+                reservation.getTheme().getPrice()
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public String getTime() {
+        return time;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getThemeName() {
+        return themeName;
+    }
+
+    public String getThemeDesc() {
+        return themeDesc;
+    }
+
+    public Integer getThemePrice() {
+        return themePrice;
+    }
+}

--- a/src/main/java/nextstep/dto/response/ReservationResponse.java
+++ b/src/main/java/nextstep/dto/response/ReservationResponse.java
@@ -1,0 +1,64 @@
+package nextstep.dto.response;
+
+import nextstep.Reservation;
+
+public class ReservationResponse {
+
+    private final Long id;
+    private final String date;
+    private final String time;
+    private final String name;
+    private final String themeName;
+    private final String themeDesc;
+    private final Integer themePrice;
+
+    private ReservationResponse(Long id, String date, String time, String name, String themeName, String themeDesc, Integer themePrice) {
+        this.id = id;
+        this.date = date;
+        this.time = time;
+        this.name = name;
+        this.themeName = themeName;
+        this.themeDesc = themeDesc;
+        this.themePrice = themePrice;
+    }
+
+    public static ReservationResponse fromEntity(Reservation reservation) {
+        return new ReservationResponse(
+                reservation.getId(),
+                reservation.getDate().toString(),
+                reservation.getTime().toString(),
+                reservation.getName(),
+                reservation.getTheme().getName(),
+                reservation.getTheme().getDesc(),
+                reservation.getTheme().getPrice()
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public String getTime() {
+        return time;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getThemeName() {
+        return themeName;
+    }
+
+    public String getThemeDesc() {
+        return themeDesc;
+    }
+
+    public Integer getThemePrice() {
+        return themePrice;
+    }
+}

--- a/src/main/java/nextstep/exception/DatabaseException.java
+++ b/src/main/java/nextstep/exception/DatabaseException.java
@@ -1,0 +1,10 @@
+package nextstep.exception;
+
+public class DatabaseException extends RuntimeException {
+    public DatabaseException(Throwable cause) {
+        this("데이터베이스에 문제가 발생했습니다.", cause);
+    }
+    public DatabaseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/nextstep/exception/DuplicateReservationException.java
+++ b/src/main/java/nextstep/exception/DuplicateReservationException.java
@@ -1,0 +1,10 @@
+package nextstep.exception;
+
+public class DuplicateReservationException extends RuntimeException {
+    public DuplicateReservationException() {
+        this("같은 시간에 이미 예약이 있습니다.");
+    }
+    public DuplicateReservationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/exception/ReservationNotFoundException.java
+++ b/src/main/java/nextstep/exception/ReservationNotFoundException.java
@@ -1,0 +1,10 @@
+package nextstep.exception;
+
+public class ReservationNotFoundException extends RuntimeException {
+    public ReservationNotFoundException() {
+        this("예약을 찾을 수 없습니다.");
+    }
+    public ReservationNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/repository/ReservationH2JdbcTemplateRepository.java
+++ b/src/main/java/nextstep/repository/ReservationH2JdbcTemplateRepository.java
@@ -2,6 +2,7 @@ package nextstep.repository;
 
 import nextstep.Reservation;
 import nextstep.exception.ReservationNotFoundException;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -14,6 +15,7 @@ import java.sql.Time;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+@Qualifier("jdbcTemplate")
 @Repository
 public class ReservationH2JdbcTemplateRepository implements ReservationRepository {
     private final JdbcTemplate jdbcTemplate;

--- a/src/main/java/nextstep/repository/ReservationH2JdbcTemplateRepository.java
+++ b/src/main/java/nextstep/repository/ReservationH2JdbcTemplateRepository.java
@@ -1,7 +1,6 @@
 package nextstep.repository;
 
 import nextstep.Reservation;
-import nextstep.Theme;
 import nextstep.exception.ReservationNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -51,17 +50,7 @@ public class ReservationH2JdbcTemplateRepository implements ReservationRepositor
         try {
             return jdbcTemplate.queryForObject(
                     sql,
-                    (resultSet, rowNum) -> new Reservation(
-                                resultSet.getLong("id"),
-                                resultSet.getDate(2).toLocalDate(),
-                                resultSet.getTime(3).toLocalTime(),
-                                resultSet.getString(4),
-                                new Theme(
-                                        resultSet.getString(5),
-                                        resultSet.getString(6),
-                                        resultSet.getInt(7)
-                                )
-                        ),
+                    (resultSet, rowNum) -> Reservation.fromResultSet(resultSet),
                     id);
         } catch (EmptyResultDataAccessException e) {
             throw new ReservationNotFoundException();

--- a/src/main/java/nextstep/repository/ReservationH2JdbcTemplateRepository.java
+++ b/src/main/java/nextstep/repository/ReservationH2JdbcTemplateRepository.java
@@ -1,0 +1,72 @@
+package nextstep.repository;
+
+import nextstep.Reservation;
+import nextstep.Theme;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.Time;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Repository
+public class ReservationH2JdbcTemplateRepository implements ReservationRepository{
+    private final JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public ReservationH2JdbcTemplateRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+
+    @Override
+    public Reservation add(Reservation reservation) {
+        String sql = "INSERT INTO reservation (date, time, name, theme_name, theme_desc, theme_price) VALUES (?, ?, ?, ?, ?, ?);";
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement ps = connection.prepareStatement(sql, new String[]{"id"});
+            ps.setDate(1, Date.valueOf(reservation.getDate()));
+            ps.setTime(2, Time.valueOf(reservation.getTime()));
+            ps.setString(3, reservation.getName());
+            ps.setString(4, reservation.getTheme().getName());
+            ps.setString(5, reservation.getTheme().getDesc());
+            ps.setInt(6, reservation.getTheme().getPrice());
+            return ps;
+        }, keyHolder);
+
+        reservation.setId(keyHolder.getKey().longValue());
+        return reservation;
+    }
+
+    @Override
+    public Reservation get(Long id) {
+        String sql = "SELECT * FROM reservation where id = ?";
+        return jdbcTemplate.queryForObject(
+                sql,
+                (resultSet, rowNum) -> {
+                    Reservation reservation = new Reservation(
+                        resultSet.getLong("id"),
+                        resultSet.getDate(2).toLocalDate(),
+                        resultSet.getTime(3).toLocalTime(),
+                        resultSet.getString(4),
+                        new Theme(
+                            resultSet.getString(5),
+                            resultSet.getString(6),
+                            resultSet.getInt(7)
+                        )
+                    );
+                    return reservation;
+                }, id);
+    }
+
+    @Override
+    public void delete(Long id) {
+        String sql = "DELETE FROM reservation where id = ?";
+        jdbcTemplate.update(sql, id);
+    }
+}

--- a/src/main/java/nextstep/repository/ReservationH2JdbcTemplateRepository.java
+++ b/src/main/java/nextstep/repository/ReservationH2JdbcTemplateRepository.java
@@ -3,6 +3,7 @@ package nextstep.repository;
 import nextstep.Reservation;
 import nextstep.exception.ReservationNotFoundException;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;

--- a/src/main/java/nextstep/repository/ReservationH2JdbcTemplateRepository.java
+++ b/src/main/java/nextstep/repository/ReservationH2JdbcTemplateRepository.java
@@ -17,7 +17,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Repository
-public class ReservationH2JdbcTemplateRepository implements ReservationRepository{
+public class ReservationH2JdbcTemplateRepository implements ReservationRepository {
     private final JdbcTemplate jdbcTemplate;
 
     @Autowired
@@ -64,7 +64,7 @@ public class ReservationH2JdbcTemplateRepository implements ReservationRepositor
                         ),
                     id);
         } catch (EmptyResultDataAccessException e) {
-            throw new ReservationNotFoundException(e.getMessage());
+            throw new ReservationNotFoundException();
         }
     }
 
@@ -72,5 +72,12 @@ public class ReservationH2JdbcTemplateRepository implements ReservationRepositor
     public void delete(Long id) {
         String sql = "DELETE FROM reservation where id = ?";
         jdbcTemplate.update(sql, id);
+    }
+
+    @Override
+    public boolean hasReservationAt(LocalDate date, LocalTime time) {
+        String sql = "SELECT count(*) AS cnt FROM reservation WHERE date = ? AND time = ?";
+        int count = jdbcTemplate.queryForObject(sql, Integer.class, Date.valueOf(date), Time.valueOf(time));
+        return count >= 1;
     }
 }

--- a/src/main/java/nextstep/repository/ReservationH2JdbcTemplateRepository.java
+++ b/src/main/java/nextstep/repository/ReservationH2JdbcTemplateRepository.java
@@ -3,7 +3,6 @@ package nextstep.repository;
 import nextstep.Reservation;
 import nextstep.exception.ReservationNotFoundException;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -15,6 +14,7 @@ import java.sql.PreparedStatement;
 import java.sql.Time;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 @Qualifier("jdbcTemplate")
 @Repository
@@ -65,8 +65,14 @@ public class ReservationH2JdbcTemplateRepository implements ReservationRepositor
 
     @Override
     public boolean hasReservationAt(LocalDate date, LocalTime time) {
-        String sql = "SELECT count(*) AS cnt FROM reservation WHERE date = ? AND time = ?";
-        int count = jdbcTemplate.queryForObject(sql, Integer.class, Date.valueOf(date), Time.valueOf(time));
-        return count >= 1;
+        String sql = "SELECT id AS cnt FROM reservation WHERE date = ? AND time = ? LIMIT 1";
+        List<Long> reservationIds = jdbcTemplate.query(
+                sql,
+                (rs, rowNum) -> rs.getLong("id"),
+                Date.valueOf(date),
+                Time.valueOf(time)
+        );
+
+        return reservationIds.size() == 1;
     }
 }

--- a/src/main/java/nextstep/repository/ReservationH2JdbcTemplateRepository.java
+++ b/src/main/java/nextstep/repository/ReservationH2JdbcTemplateRepository.java
@@ -2,7 +2,6 @@ package nextstep.repository;
 
 import nextstep.Reservation;
 import nextstep.exception.ReservationNotFoundException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -19,11 +18,9 @@ import java.time.LocalTime;
 public class ReservationH2JdbcTemplateRepository implements ReservationRepository {
     private final JdbcTemplate jdbcTemplate;
 
-    @Autowired
     public ReservationH2JdbcTemplateRepository(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
     }
-
 
     @Override
     public Reservation add(Reservation reservation) {

--- a/src/main/java/nextstep/repository/ReservationH2JdbcTemplateRepository.java
+++ b/src/main/java/nextstep/repository/ReservationH2JdbcTemplateRepository.java
@@ -49,7 +49,7 @@ public class ReservationH2JdbcTemplateRepository implements ReservationRepositor
         try {
             return jdbcTemplate.queryForObject(
                     sql,
-                    (resultSet, rowNum) -> Reservation.fromResultSet(resultSet),
+                    (resultSet, rowNum) -> ReservationResultSetMapper.mapRow(resultSet),
                     id);
         } catch (EmptyResultDataAccessException e) {
             throw new ReservationNotFoundException();

--- a/src/main/java/nextstep/repository/ReservationH2Repository.java
+++ b/src/main/java/nextstep/repository/ReservationH2Repository.java
@@ -89,6 +89,27 @@ public class ReservationH2Repository implements ReservationRepository{
         }
     }
 
+    @Override
+    public boolean hasReservationAt(LocalDate date, LocalTime time) {
+        Connection con = getConnection();
+
+        try {
+            String sql = "SELECT count(*) AS cnt FROM reservation WHERE date = ? AND time = ?";
+            PreparedStatement ps = con.prepareStatement(sql);
+            ps.setDate(1, Date.valueOf(date));
+            ps.setTime(2, Time.valueOf(time));
+            ResultSet rs = ps.executeQuery();
+
+            rs.next();
+            int cnt = rs.getInt("cnt");
+            return cnt >= 1;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } finally {
+            closeConnection(con);
+        }
+    }
+
     private Connection getConnection() {
         Connection con = null;
 

--- a/src/main/java/nextstep/repository/ReservationH2Repository.java
+++ b/src/main/java/nextstep/repository/ReservationH2Repository.java
@@ -2,6 +2,7 @@ package nextstep.repository;
 
 import nextstep.Reservation;
 import nextstep.Theme;
+import nextstep.exception.ReservationNotFoundException;
 
 import java.sql.*;
 import java.time.LocalDate;
@@ -31,15 +32,15 @@ public class ReservationH2Repository implements ReservationRepository{
             }
         } catch (SQLException e) {
             throw new RuntimeException(e);
+        } finally {
+            closeConnection(con);
         }
-
-        closeConnection(con);
 
         return reservation;
     }
 
     @Override
-    public Reservation get(Long id) {
+    public Reservation get(Long id) throws ReservationNotFoundException {
         Connection con = getConnection();
         Reservation result = null;
 
@@ -60,12 +61,14 @@ public class ReservationH2Repository implements ReservationRepository{
                 Theme reservationTheme = new Theme(themeName, themeDesc, themePrice);
 
                 result = new Reservation(reservationId, reservationDate, reservationTime, reservationName, reservationTheme);
+            } else {
+                throw new ReservationNotFoundException();
             }
         } catch (SQLException e) {
             throw new RuntimeException(e);
+        } finally {
+            closeConnection(con);
         }
-
-        closeConnection(con);
 
         return result;
     }
@@ -81,9 +84,9 @@ public class ReservationH2Repository implements ReservationRepository{
             ps.executeUpdate();
         } catch (SQLException e) {
             throw new RuntimeException(e);
+        } finally {
+            closeConnection(con);
         }
-
-        closeConnection(con);
     }
 
     private Connection getConnection() {

--- a/src/main/java/nextstep/repository/ReservationH2Repository.java
+++ b/src/main/java/nextstep/repository/ReservationH2Repository.java
@@ -11,16 +11,7 @@ public class ReservationH2Repository implements ReservationRepository{
 
     @Override
     public Reservation add(Reservation reservation) {
-        Connection con = null;
-
-        // 드라이버 연결
-        try {
-            con = DriverManager.getConnection("jdbc:h2:~/test;AUTO_SERVER=true", "sa", "");
-            System.out.println("정상적으로 연결되었습니다.");
-        } catch (SQLException e) {
-            System.err.println("연결 오류:" + e.getMessage());
-            e.printStackTrace();
-        }
+        Connection con = getConnection();
 
         try {
             String sql = "INSERT INTO reservation (date, time, name, theme_name, theme_desc, theme_price) VALUES (?, ?, ?, ?, ?, ?);";
@@ -42,29 +33,15 @@ public class ReservationH2Repository implements ReservationRepository{
             throw new RuntimeException(e);
         }
 
-        try {
-            if (con != null)
-                con.close();
-        } catch (SQLException e) {
-            System.err.println("con 오류:" + e.getMessage());
-        }
+        closeConnection(con);
 
         return reservation;
     }
 
     @Override
     public Reservation get(Long id) {
-        Connection con = null;
+        Connection con = getConnection();
         Reservation result = null;
-
-        // 드라이버 연결
-        try {
-            con = DriverManager.getConnection("jdbc:h2:~/test;AUTO_SERVER=true", "sa", "");
-            System.out.println("정상적으로 연결되었습니다.");
-        } catch (SQLException e) {
-            System.err.println("연결 오류:" + e.getMessage());
-            e.printStackTrace();
-        }
 
         try {
             String sql = "SELECT * FROM reservation WHERE id = ?";
@@ -88,28 +65,14 @@ public class ReservationH2Repository implements ReservationRepository{
             throw new RuntimeException(e);
         }
 
-        try {
-            if (con != null)
-                con.close();
-        } catch (SQLException e) {
-            System.err.println("con 오류:" + e.getMessage());
-        }
+        closeConnection(con);
 
         return result;
     }
 
     @Override
     public void delete(Long id) {
-        Connection con = null;
-
-        // 드라이버 연결
-        try {
-            con = DriverManager.getConnection("jdbc:h2:~/test;AUTO_SERVER=true", "sa", "");
-            System.out.println("정상적으로 연결되었습니다.");
-        } catch (SQLException e) {
-            System.err.println("연결 오류:" + e.getMessage());
-            e.printStackTrace();
-        }
+        Connection con = getConnection();
 
         try {
             String sql = "DELETE FROM reservation WHERE id = ?";
@@ -120,6 +83,24 @@ public class ReservationH2Repository implements ReservationRepository{
             throw new RuntimeException(e);
         }
 
+        closeConnection(con);
+    }
+
+    private Connection getConnection() {
+        Connection con = null;
+
+        // 드라이버 연결
+        try {
+            con = DriverManager.getConnection("jdbc:h2:~/test;AUTO_SERVER=true", "sa", "");
+            System.out.println("정상적으로 연결되었습니다.");
+        } catch (SQLException e) {
+            System.err.println("연결 오류:" + e.getMessage());
+            e.printStackTrace();
+        }
+        return con;
+    }
+
+    private void closeConnection(Connection con) {
         try {
             if (con != null)
                 con.close();

--- a/src/main/java/nextstep/repository/ReservationH2Repository.java
+++ b/src/main/java/nextstep/repository/ReservationH2Repository.java
@@ -93,15 +93,13 @@ public class ReservationH2Repository implements ReservationRepository {
 
         try {
             con = getConnection();
-            String sql = "SELECT count(*) AS cnt FROM reservation WHERE date = ? AND time = ?";
+            String sql = "SELECT id AS cnt FROM reservation WHERE date = ? AND time = ? LIMIT 1";
             ps = con.prepareStatement(sql);
             ps.setDate(1, Date.valueOf(date));
             ps.setTime(2, Time.valueOf(time));
             rs = ps.executeQuery();
 
-            rs.next();
-            int cnt = rs.getInt("cnt");
-            return cnt >= 1;
+            return rs.next();
         } catch (SQLException e) {
             throw new DatabaseException(e);
         } finally {

--- a/src/main/java/nextstep/repository/ReservationH2Repository.java
+++ b/src/main/java/nextstep/repository/ReservationH2Repository.java
@@ -1,0 +1,130 @@
+package nextstep.repository;
+
+import nextstep.Reservation;
+import nextstep.Theme;
+
+import java.sql.*;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class ReservationH2Repository implements ReservationRepository{
+
+    @Override
+    public Reservation add(Reservation reservation) {
+        Connection con = null;
+
+        // 드라이버 연결
+        try {
+            con = DriverManager.getConnection("jdbc:h2:~/test;AUTO_SERVER=true", "sa", "");
+            System.out.println("정상적으로 연결되었습니다.");
+        } catch (SQLException e) {
+            System.err.println("연결 오류:" + e.getMessage());
+            e.printStackTrace();
+        }
+
+        try {
+            String sql = "INSERT INTO reservation (date, time, name, theme_name, theme_desc, theme_price) VALUES (?, ?, ?, ?, ?, ?);";
+            PreparedStatement ps = con.prepareStatement(sql, new String[]{"id"});
+            ps.setDate(1, Date.valueOf(reservation.getDate()));
+            ps.setTime(2, Time.valueOf(reservation.getTime()));
+            ps.setString(3, reservation.getName());
+            ps.setString(4, reservation.getTheme().getName());
+            ps.setString(5, reservation.getTheme().getDesc());
+            ps.setInt(6, reservation.getTheme().getPrice());
+            ps.executeUpdate();
+            ResultSet rs = ps.getGeneratedKeys();
+
+            if (rs.next()) {
+                Long id = rs.getLong(1);
+                reservation.setId(id);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+        try {
+            if (con != null)
+                con.close();
+        } catch (SQLException e) {
+            System.err.println("con 오류:" + e.getMessage());
+        }
+
+        return reservation;
+    }
+
+    @Override
+    public Reservation get(Long id) {
+        Connection con = null;
+        Reservation result = null;
+
+        // 드라이버 연결
+        try {
+            con = DriverManager.getConnection("jdbc:h2:~/test;AUTO_SERVER=true", "sa", "");
+            System.out.println("정상적으로 연결되었습니다.");
+        } catch (SQLException e) {
+            System.err.println("연결 오류:" + e.getMessage());
+            e.printStackTrace();
+        }
+
+        try {
+            String sql = "SELECT * FROM reservation WHERE id = ?";
+            PreparedStatement ps = con.prepareStatement(sql);
+            ps.setLong(1, id);
+            ResultSet rs = ps.executeQuery();
+
+            if (rs.next()) {
+                Long reservationId = rs.getLong("id");
+                LocalDate reservationDate = rs.getDate(2).toLocalDate();
+                LocalTime reservationTime = rs.getTime(3).toLocalTime();
+                String reservationName = rs.getString(4);
+                String themeName = rs.getString(5);
+                String themeDesc = rs.getString(6);
+                Integer themePrice = rs.getInt(7);
+                Theme reservationTheme = new Theme(themeName, themeDesc, themePrice);
+
+                result = new Reservation(reservationId, reservationDate, reservationTime, reservationName, reservationTheme);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+        try {
+            if (con != null)
+                con.close();
+        } catch (SQLException e) {
+            System.err.println("con 오류:" + e.getMessage());
+        }
+
+        return result;
+    }
+
+    @Override
+    public void delete(Long id) {
+        Connection con = null;
+
+        // 드라이버 연결
+        try {
+            con = DriverManager.getConnection("jdbc:h2:~/test;AUTO_SERVER=true", "sa", "");
+            System.out.println("정상적으로 연결되었습니다.");
+        } catch (SQLException e) {
+            System.err.println("연결 오류:" + e.getMessage());
+            e.printStackTrace();
+        }
+
+        try {
+            String sql = "DELETE FROM reservation WHERE id = ?";
+            PreparedStatement ps = con.prepareStatement(sql);
+            ps.setLong(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+        try {
+            if (con != null)
+                con.close();
+        } catch (SQLException e) {
+            System.err.println("con 오류:" + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/nextstep/repository/ReservationH2Repository.java
+++ b/src/main/java/nextstep/repository/ReservationH2Repository.java
@@ -7,7 +7,7 @@ import java.sql.*;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-public class ReservationH2Repository implements ReservationRepository{
+public class ReservationH2Repository implements ReservationRepository {
 
     @Override
     public Reservation add(Reservation reservation) {
@@ -50,7 +50,7 @@ public class ReservationH2Repository implements ReservationRepository{
             ResultSet rs = ps.executeQuery();
 
             if (rs.next()) {
-                result = Reservation.fromResultSet(rs);
+                result = ReservationResultSetMapper.mapRow(rs);
             } else {
                 throw new ReservationNotFoundException();
             }

--- a/src/main/java/nextstep/repository/ReservationH2Repository.java
+++ b/src/main/java/nextstep/repository/ReservationH2Repository.java
@@ -1,6 +1,7 @@
 package nextstep.repository;
 
 import nextstep.Reservation;
+import nextstep.exception.DatabaseException;
 import nextstep.exception.ReservationNotFoundException;
 
 import java.sql.*;
@@ -30,7 +31,7 @@ public class ReservationH2Repository implements ReservationRepository {
                 reservation.setId(id);
             }
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new DatabaseException(e);
         } finally {
             closeConnection(con);
         }
@@ -55,7 +56,7 @@ public class ReservationH2Repository implements ReservationRepository {
                 throw new ReservationNotFoundException();
             }
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new DatabaseException(e);
         } finally {
             closeConnection(con);
         }
@@ -73,7 +74,7 @@ public class ReservationH2Repository implements ReservationRepository {
             ps.setLong(1, id);
             ps.executeUpdate();
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new DatabaseException(e);
         } finally {
             closeConnection(con);
         }
@@ -94,7 +95,7 @@ public class ReservationH2Repository implements ReservationRepository {
             int cnt = rs.getInt("cnt");
             return cnt >= 1;
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new DatabaseException(e);
         } finally {
             closeConnection(con);
         }
@@ -110,6 +111,7 @@ public class ReservationH2Repository implements ReservationRepository {
         } catch (SQLException e) {
             System.err.println("연결 오류:" + e.getMessage());
             e.printStackTrace();
+            throw new DatabaseException(e);
         }
         return con;
     }
@@ -120,6 +122,7 @@ public class ReservationH2Repository implements ReservationRepository {
                 con.close();
         } catch (SQLException e) {
             System.err.println("con 오류:" + e.getMessage());
+            throw new DatabaseException(e);
         }
     }
 }

--- a/src/main/java/nextstep/repository/ReservationH2Repository.java
+++ b/src/main/java/nextstep/repository/ReservationH2Repository.java
@@ -1,7 +1,6 @@
 package nextstep.repository;
 
 import nextstep.Reservation;
-import nextstep.Theme;
 import nextstep.exception.ReservationNotFoundException;
 
 import java.sql.*;
@@ -51,16 +50,7 @@ public class ReservationH2Repository implements ReservationRepository{
             ResultSet rs = ps.executeQuery();
 
             if (rs.next()) {
-                Long reservationId = rs.getLong("id");
-                LocalDate reservationDate = rs.getDate(2).toLocalDate();
-                LocalTime reservationTime = rs.getTime(3).toLocalTime();
-                String reservationName = rs.getString(4);
-                String themeName = rs.getString(5);
-                String themeDesc = rs.getString(6);
-                Integer themePrice = rs.getInt(7);
-                Theme reservationTheme = new Theme(themeName, themeDesc, themePrice);
-
-                result = new Reservation(reservationId, reservationDate, reservationTime, reservationName, reservationTheme);
+                result = Reservation.fromResultSet(rs);
             } else {
                 throw new ReservationNotFoundException();
             }

--- a/src/main/java/nextstep/repository/ReservationMemoryRepository.java
+++ b/src/main/java/nextstep/repository/ReservationMemoryRepository.java
@@ -27,6 +27,6 @@ public class ReservationMemoryRepository implements ReservationRepository {
 
     @Override
     public void delete(Long id) {
-
+        reservations.remove(id);
     }
 }

--- a/src/main/java/nextstep/repository/ReservationMemoryRepository.java
+++ b/src/main/java/nextstep/repository/ReservationMemoryRepository.java
@@ -2,12 +2,14 @@ package nextstep.repository;
 
 import nextstep.Reservation;
 import nextstep.exception.ReservationNotFoundException;
+import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.Map;
 
+@Repository
 public class ReservationMemoryRepository implements ReservationRepository {
     private final Map<Long, Reservation> reservations = new HashMap<>();
     private Long reservationIdIndex = 0L;

--- a/src/main/java/nextstep/repository/ReservationMemoryRepository.java
+++ b/src/main/java/nextstep/repository/ReservationMemoryRepository.java
@@ -11,6 +11,8 @@ public class ReservationMemoryRepository implements ReservationRepository {
     private final Map<Long, Reservation> reservations = new HashMap<>();
     private Long reservationIdIndex = 0L;
 
+
+
     @Override
     public Reservation add(Reservation reservation) {
         reservation.setId(reservationIdIndex++);
@@ -20,7 +22,7 @@ public class ReservationMemoryRepository implements ReservationRepository {
 
     @Override
     public Reservation get(Long id) {
-        return null;
+        return reservations.get(id);
     }
 
     @Override

--- a/src/main/java/nextstep/repository/ReservationMemoryRepository.java
+++ b/src/main/java/nextstep/repository/ReservationMemoryRepository.java
@@ -1,9 +1,10 @@
 package nextstep.repository;
 
 import nextstep.Reservation;
-import nextstep.exception.DuplicateReservationException;
 import nextstep.exception.ReservationNotFoundException;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -15,19 +16,15 @@ public class ReservationMemoryRepository implements ReservationRepository {
 
     @Override
     public Reservation add(Reservation newReservation) {
-        validateDateTime(newReservation);
-
         newReservation.setId(reservationIdIndex++);
         reservations.put(newReservation.getId(), newReservation);
         return newReservation;
     }
 
-    private void validateDateTime(Reservation newReservation) {
-        boolean isDuplicateReservation = reservations.values().stream()
-                .anyMatch(reservation -> reservation.hasSameDateTime(newReservation));
-        if (isDuplicateReservation) {
-            throw new DuplicateReservationException();
-        }
+    @Override
+    public boolean hasReservationAt(LocalDate date, LocalTime time) {
+        return reservations.values().stream()
+                .anyMatch(reservation -> reservation.isAtDateTime(date, time));
     }
 
     @Override

--- a/src/main/java/nextstep/repository/ReservationMemoryRepository.java
+++ b/src/main/java/nextstep/repository/ReservationMemoryRepository.java
@@ -1,0 +1,30 @@
+package nextstep.repository;
+
+import nextstep.Reservation;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Repository
+public class ReservationMemoryRepository implements ReservationRepository {
+    private final Map<Long, Reservation> reservations = new HashMap<>();
+    private Long reservationIdIndex = 0L;
+
+    @Override
+    public Reservation add(Reservation reservation) {
+        reservation.setId(reservationIdIndex++);
+        reservations.put(reservation.getId(), reservation);
+        return reservation;
+    }
+
+    @Override
+    public Reservation get(Long id) {
+        return null;
+    }
+
+    @Override
+    public void delete(Long id) {
+
+    }
+}

--- a/src/main/java/nextstep/repository/ReservationMemoryRepository.java
+++ b/src/main/java/nextstep/repository/ReservationMemoryRepository.java
@@ -1,6 +1,7 @@
 package nextstep.repository;
 
 import nextstep.Reservation;
+import nextstep.exception.DuplicateReservationException;
 import org.springframework.stereotype.Repository;
 
 import java.util.HashMap;
@@ -14,10 +15,20 @@ public class ReservationMemoryRepository implements ReservationRepository {
 
 
     @Override
-    public Reservation add(Reservation reservation) {
-        reservation.setId(reservationIdIndex++);
-        reservations.put(reservation.getId(), reservation);
-        return reservation;
+    public Reservation add(Reservation newReservation) {
+        validateDateTime(newReservation);
+
+        newReservation.setId(reservationIdIndex++);
+        reservations.put(newReservation.getId(), newReservation);
+        return newReservation;
+    }
+
+    private void validateDateTime(Reservation newReservation) {
+        boolean isDuplicateReservation = reservations.values().stream()
+                .anyMatch(reservation -> reservation.hasSameDateTime(newReservation));
+        if (isDuplicateReservation) {
+            throw new DuplicateReservationException();
+        }
     }
 
     @Override

--- a/src/main/java/nextstep/repository/ReservationMemoryRepository.java
+++ b/src/main/java/nextstep/repository/ReservationMemoryRepository.java
@@ -2,12 +2,10 @@ package nextstep.repository;
 
 import nextstep.Reservation;
 import nextstep.exception.DuplicateReservationException;
-import org.springframework.stereotype.Repository;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@Repository
 public class ReservationMemoryRepository implements ReservationRepository {
     private final Map<Long, Reservation> reservations = new HashMap<>();
     private Long reservationIdIndex = 0L;

--- a/src/main/java/nextstep/repository/ReservationMemoryRepository.java
+++ b/src/main/java/nextstep/repository/ReservationMemoryRepository.java
@@ -2,6 +2,7 @@ package nextstep.repository;
 
 import nextstep.Reservation;
 import nextstep.exception.DuplicateReservationException;
+import nextstep.exception.ReservationNotFoundException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,8 +31,14 @@ public class ReservationMemoryRepository implements ReservationRepository {
     }
 
     @Override
-    public Reservation get(Long id) {
-        return reservations.get(id);
+    public Reservation get(Long id)  throws ReservationNotFoundException {
+        Reservation reservation = reservations.get(id);
+
+        if (reservation == null) {
+            throw new ReservationNotFoundException();
+        }
+
+        return reservation;
     }
 
     @Override

--- a/src/main/java/nextstep/repository/ReservationRepository.java
+++ b/src/main/java/nextstep/repository/ReservationRepository.java
@@ -1,0 +1,9 @@
+package nextstep.repository;
+
+import nextstep.Reservation;
+
+public interface ReservationRepository {
+    Reservation add(Reservation reservation);
+    Reservation get(Long id);
+    void delete(Long id);
+}

--- a/src/main/java/nextstep/repository/ReservationRepository.java
+++ b/src/main/java/nextstep/repository/ReservationRepository.java
@@ -1,9 +1,10 @@
 package nextstep.repository;
 
 import nextstep.Reservation;
+import nextstep.exception.ReservationNotFoundException;
 
 public interface ReservationRepository {
     Reservation add(Reservation reservation);
-    Reservation get(Long id);
+    Reservation get(Long id) throws ReservationNotFoundException;
     void delete(Long id);
 }

--- a/src/main/java/nextstep/repository/ReservationRepository.java
+++ b/src/main/java/nextstep/repository/ReservationRepository.java
@@ -3,8 +3,12 @@ package nextstep.repository;
 import nextstep.Reservation;
 import nextstep.exception.ReservationNotFoundException;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+
 public interface ReservationRepository {
     Reservation add(Reservation reservation);
     Reservation get(Long id) throws ReservationNotFoundException;
     void delete(Long id);
+    boolean hasReservationAt(LocalDate date, LocalTime time);
 }

--- a/src/main/java/nextstep/repository/ReservationResultSetMapper.java
+++ b/src/main/java/nextstep/repository/ReservationResultSetMapper.java
@@ -1,0 +1,24 @@
+package nextstep.repository;
+
+import nextstep.Reservation;
+import nextstep.Theme;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+
+public class ReservationResultSetMapper {
+    public static Reservation mapRow(ResultSet rs) throws SQLException {
+        return Reservation.of(
+                rs.getLong("id"),
+                rs.getDate("date").toLocalDate(),
+                rs.getTime("time").toLocalTime(),
+                rs.getString("name"),
+                Theme.of(
+                        rs.getString("theme_name"),
+                        rs.getString("theme_desc"),
+                        rs.getInt("theme_price")
+                )
+        );
+    }
+}

--- a/src/main/java/nextstep/service/RoomEscapeService.java
+++ b/src/main/java/nextstep/service/RoomEscapeService.java
@@ -6,13 +6,14 @@ import nextstep.dto.response.ReservationResponse;
 import nextstep.exception.DuplicateReservationException;
 import nextstep.exception.ReservationNotFoundException;
 import nextstep.repository.ReservationRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 @Service
 public class RoomEscapeService {
     private final ReservationRepository reservationRepository;
 
-    public RoomEscapeService(ReservationRepository reservationRepository) {
+    public RoomEscapeService(@Qualifier("jdbcTemplate") ReservationRepository reservationRepository) {
         this.reservationRepository = reservationRepository;
     }
 

--- a/src/main/java/nextstep/service/RoomEscapeService.java
+++ b/src/main/java/nextstep/service/RoomEscapeService.java
@@ -1,8 +1,8 @@
 package nextstep.service;
 
 import nextstep.Reservation;
-import nextstep.Theme;
 import nextstep.dto.request.CreateReservationRequest;
+import nextstep.dto.response.ReservationResponse;
 import nextstep.exception.DuplicateReservationException;
 import nextstep.exception.ReservationNotFoundException;
 import nextstep.repository.ReservationRepository;
@@ -11,8 +11,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class RoomEscapeService {
-    public static final Theme DEFAULT_THEME = Theme.of("워너고홈", "병맛 어드벤처 회사 코믹물", 29_000);
-
     private final ReservationRepository reservationRepository;
 
 
@@ -21,23 +19,18 @@ public class RoomEscapeService {
         this.reservationRepository = reservationRepository;
     }
 
-    public Reservation add(CreateReservationRequest request) throws DuplicateReservationException {
+    public ReservationResponse add(CreateReservationRequest request) throws DuplicateReservationException {
 
         if (reservationRepository.hasReservationAt(request.getDate(), request.getTime())) {
             throw new DuplicateReservationException();
         }
 
-        Reservation reservation = Reservation.of(
-                request.getDate(),
-                request.getTime(),
-                request.getName(),
-                DEFAULT_THEME
-        );
-        return reservationRepository.add(reservation);
+        Reservation reservation = request.toEntity();
+        return ReservationResponse.fromEntity(reservationRepository.add(reservation));
     }
 
-    public Reservation get(Long id) throws ReservationNotFoundException {
-        return reservationRepository.get(id);
+    public ReservationResponse get(Long id) throws ReservationNotFoundException {
+        return ReservationResponse.fromEntity(reservationRepository.get(id));
     }
 
     public void delete(Long id) {

--- a/src/main/java/nextstep/service/RoomEscapeService.java
+++ b/src/main/java/nextstep/service/RoomEscapeService.java
@@ -35,4 +35,8 @@ public class RoomEscapeService {
     public Reservation get(Long id) {
         return reservationRepository.get(id);
     }
+
+    public void delete(Long id) {
+        reservationRepository.delete(id);
+    }
 }

--- a/src/main/java/nextstep/service/RoomEscapeService.java
+++ b/src/main/java/nextstep/service/RoomEscapeService.java
@@ -3,6 +3,7 @@ package nextstep.service;
 import nextstep.Reservation;
 import nextstep.Theme;
 import nextstep.dto.CreateReservationRequest;
+import nextstep.exception.DuplicateReservationException;
 import nextstep.repository.ReservationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -23,9 +24,16 @@ public class RoomEscapeService {
     }
 
     public Reservation add(CreateReservationRequest request) {
+
+        LocalDate date = LocalDate.parse(request.getDate());
+        LocalTime time = LocalTime.parse(request.getTime() + ":00");
+        if (reservationRepository.hasReservationAt(date, time)) {
+            throw new DuplicateReservationException();
+        }
+
         Reservation reservation = new Reservation(
-                LocalDate.parse(request.getDate()),
-                LocalTime.parse(request.getTime() + ":00"),
+                date,
+                time,
                 request.getName(),
                 DEFAULT_THEME
         );

--- a/src/main/java/nextstep/service/RoomEscapeService.java
+++ b/src/main/java/nextstep/service/RoomEscapeService.java
@@ -2,7 +2,7 @@ package nextstep.service;
 
 import nextstep.Reservation;
 import nextstep.Theme;
-import nextstep.dto.CreateReservationRequest;
+import nextstep.dto.request.CreateReservationRequest;
 import nextstep.exception.DuplicateReservationException;
 import nextstep.repository.ReservationRepository;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/nextstep/service/RoomEscapeService.java
+++ b/src/main/java/nextstep/service/RoomEscapeService.java
@@ -1,0 +1,34 @@
+package nextstep.service;
+
+import nextstep.Reservation;
+import nextstep.Theme;
+import nextstep.dto.CreateReservationRequest;
+import nextstep.repository.ReservationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Service
+public class RoomEscapeService {
+    public static final Theme DEFAULT_THEME = new Theme("워너고홈", "병맛 어드벤처 회사 코믹물", 29_000);
+
+    private final ReservationRepository reservationRepository;
+
+
+    @Autowired
+    public RoomEscapeService(ReservationRepository reservationRepository) {
+        this.reservationRepository = reservationRepository;
+    }
+
+    public Reservation add(CreateReservationRequest request) {
+        Reservation reservation = new Reservation(
+                LocalDate.parse(request.getDate()),
+                LocalTime.parse(request.getTime() + ":00"),
+                request.getName(),
+                DEFAULT_THEME
+        );
+        return reservationRepository.add(reservation);
+    }
+}

--- a/src/main/java/nextstep/service/RoomEscapeService.java
+++ b/src/main/java/nextstep/service/RoomEscapeService.java
@@ -13,7 +13,7 @@ import java.time.LocalTime;
 
 @Service
 public class RoomEscapeService {
-    public static final Theme DEFAULT_THEME = new Theme("워너고홈", "병맛 어드벤처 회사 코믹물", 29_000);
+    public static final Theme DEFAULT_THEME = Theme.of("워너고홈", "병맛 어드벤처 회사 코믹물", 29_000);
 
     private final ReservationRepository reservationRepository;
 
@@ -31,7 +31,7 @@ public class RoomEscapeService {
             throw new DuplicateReservationException();
         }
 
-        Reservation reservation = new Reservation(
+        Reservation reservation = Reservation.of(
                 date,
                 time,
                 request.getName(),

--- a/src/main/java/nextstep/service/RoomEscapeService.java
+++ b/src/main/java/nextstep/service/RoomEscapeService.java
@@ -2,6 +2,7 @@ package nextstep.service;
 
 import nextstep.Reservation;
 import nextstep.dto.request.CreateReservationRequest;
+import nextstep.dto.response.ReservationConsoleResponse;
 import nextstep.dto.response.ReservationResponse;
 import nextstep.exception.DuplicateReservationException;
 import nextstep.exception.ReservationNotFoundException;
@@ -17,21 +18,36 @@ public class RoomEscapeService {
         this.reservationRepository = reservationRepository;
     }
 
-    public ReservationResponse add(CreateReservationRequest request) throws DuplicateReservationException {
+    public ReservationResponse createReservationForWeb(CreateReservationRequest request) throws DuplicateReservationException {
+        return ReservationResponse.fromEntity(createReservation(request));
+    }
 
+    public ReservationConsoleResponse createReservationForConsole(CreateReservationRequest request) throws DuplicateReservationException {
+        return ReservationConsoleResponse.fromEntity(createReservation(request));
+    }
+
+    private Reservation createReservation(CreateReservationRequest request) throws DuplicateReservationException {
         if (reservationRepository.hasReservationAt(request.getDate(), request.getTime())) {
             throw new DuplicateReservationException();
         }
 
         Reservation reservation = request.toEntity();
-        return ReservationResponse.fromEntity(reservationRepository.add(reservation));
+        return reservationRepository.add(reservation);
     }
 
-    public ReservationResponse get(Long id) throws ReservationNotFoundException {
-        return ReservationResponse.fromEntity(reservationRepository.get(id));
+    public ReservationResponse findReservationForWeb(Long id) throws ReservationNotFoundException {
+        return ReservationResponse.fromEntity(findReservation(id));
     }
 
-    public void delete(Long id) {
+    public ReservationConsoleResponse findReservationForConsole(Long id) throws ReservationNotFoundException {
+        return ReservationConsoleResponse.fromEntity(findReservation(id));
+    }
+
+    private Reservation findReservation(Long id) throws ReservationNotFoundException {
+        return reservationRepository.get(id);
+    }
+
+    public void cancelReservation(Long id) {
         reservationRepository.delete(id);
     }
 }

--- a/src/main/java/nextstep/service/RoomEscapeService.java
+++ b/src/main/java/nextstep/service/RoomEscapeService.java
@@ -8,9 +8,6 @@ import nextstep.repository.ReservationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-
 @Service
 public class RoomEscapeService {
     public static final Theme DEFAULT_THEME = Theme.of("워너고홈", "병맛 어드벤처 회사 코믹물", 29_000);
@@ -25,15 +22,13 @@ public class RoomEscapeService {
 
     public Reservation add(CreateReservationRequest request) {
 
-        LocalDate date = LocalDate.parse(request.getDate());
-        LocalTime time = LocalTime.parse(request.getTime() + ":00");
-        if (reservationRepository.hasReservationAt(date, time)) {
+        if (reservationRepository.hasReservationAt(request.getDate(), request.getTime())) {
             throw new DuplicateReservationException();
         }
 
         Reservation reservation = Reservation.of(
-                date,
-                time,
+                request.getDate(),
+                request.getTime(),
                 request.getName(),
                 DEFAULT_THEME
         );

--- a/src/main/java/nextstep/service/RoomEscapeService.java
+++ b/src/main/java/nextstep/service/RoomEscapeService.java
@@ -31,4 +31,8 @@ public class RoomEscapeService {
         );
         return reservationRepository.add(reservation);
     }
+
+    public Reservation get(Long id) {
+        return reservationRepository.get(id);
+    }
 }

--- a/src/main/java/nextstep/service/RoomEscapeService.java
+++ b/src/main/java/nextstep/service/RoomEscapeService.java
@@ -4,6 +4,7 @@ import nextstep.Reservation;
 import nextstep.Theme;
 import nextstep.dto.request.CreateReservationRequest;
 import nextstep.exception.DuplicateReservationException;
+import nextstep.exception.ReservationNotFoundException;
 import nextstep.repository.ReservationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -20,7 +21,7 @@ public class RoomEscapeService {
         this.reservationRepository = reservationRepository;
     }
 
-    public Reservation add(CreateReservationRequest request) {
+    public Reservation add(CreateReservationRequest request) throws DuplicateReservationException {
 
         if (reservationRepository.hasReservationAt(request.getDate(), request.getTime())) {
             throw new DuplicateReservationException();
@@ -35,7 +36,7 @@ public class RoomEscapeService {
         return reservationRepository.add(reservation);
     }
 
-    public Reservation get(Long id) {
+    public Reservation get(Long id) throws ReservationNotFoundException {
         return reservationRepository.get(id);
     }
 

--- a/src/main/java/nextstep/service/RoomEscapeService.java
+++ b/src/main/java/nextstep/service/RoomEscapeService.java
@@ -6,15 +6,12 @@ import nextstep.dto.response.ReservationResponse;
 import nextstep.exception.DuplicateReservationException;
 import nextstep.exception.ReservationNotFoundException;
 import nextstep.repository.ReservationRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class RoomEscapeService {
     private final ReservationRepository reservationRepository;
 
-
-    @Autowired
     public RoomEscapeService(ReservationRepository reservationRepository) {
         this.reservationRepository = reservationRepository;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+spring:
+  h2:
+    console:
+      enabled: true

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,11 @@
+CREATE TABLE RESERVATION
+(
+    id          bigint not null auto_increment,
+    date        date,
+    time        time,
+    name        varchar(20),
+    theme_name  varchar(20),
+    theme_desc  varchar(255),
+    theme_price int,
+    primary key (id)
+);

--- a/src/test/java/nextstep/repository/ReservationMemoryRepositoryTest.java
+++ b/src/test/java/nextstep/repository/ReservationMemoryRepositoryTest.java
@@ -1,6 +1,7 @@
 package nextstep.repository;
 
 import nextstep.Reservation;
+import nextstep.Theme;
 import nextstep.service.RoomEscapeService;
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +20,7 @@ class ReservationMemoryRepositoryTest {
                 LocalDate.parse("2022-08-11"),
                 LocalTime.parse("13:00:00"),
                 "jin",
-                RoomEscapeService.DEFAULT_THEME
+                Theme.DEFAULT_THEME
         );
     }
 
@@ -34,7 +35,7 @@ class ReservationMemoryRepositoryTest {
                 LocalDate.parse("2022-08-11"),
                 LocalTime.parse("13:00:00"),
                 "jin",
-                RoomEscapeService.DEFAULT_THEME
+                Theme.DEFAULT_THEME
         );
         assertThat(addedReservation).isEqualTo(expected);
     }
@@ -50,7 +51,7 @@ class ReservationMemoryRepositoryTest {
                 LocalDate.parse("2022-08-11"),
                 LocalTime.parse("13:00:00"),
                 "jin",
-                RoomEscapeService.DEFAULT_THEME
+                Theme.DEFAULT_THEME
         );
         assertThat(addedReservation).isEqualTo(expected);
     }

--- a/src/test/java/nextstep/repository/ReservationMemoryRepositoryTest.java
+++ b/src/test/java/nextstep/repository/ReservationMemoryRepositoryTest.java
@@ -1,0 +1,36 @@
+package nextstep.repository;
+
+import nextstep.Reservation;
+import nextstep.service.RoomEscapeService;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class ReservationMemoryRepositoryTest {
+
+    private final ReservationMemoryRepository repository = new ReservationMemoryRepository();
+    @Test
+    public void should_createAndIncreaseIndex_when_addRequestGiven() {
+        Reservation reservation = new Reservation(
+                LocalDate.parse("2022-08-11"),
+                LocalTime.parse("13:00:00"),
+                "jin",
+                RoomEscapeService.DEFAULT_THEME
+        );
+
+        Reservation addedReservation = repository.add(reservation);
+
+        Reservation expected = new Reservation(
+                0L,
+                LocalDate.parse("2022-08-11"),
+                LocalTime.parse("13:00:00"),
+                "jin",
+                RoomEscapeService.DEFAULT_THEME
+        );
+        assertThat(addedReservation).isEqualTo(expected);
+    }
+}

--- a/src/test/java/nextstep/repository/ReservationMemoryRepositoryTest.java
+++ b/src/test/java/nextstep/repository/ReservationMemoryRepositoryTest.java
@@ -33,4 +33,26 @@ class ReservationMemoryRepositoryTest {
         );
         assertThat(addedReservation).isEqualTo(expected);
     }
+
+    @Test
+    public void should_findRightReservation_when_findRequestGiven() {
+        Reservation reservation = new Reservation(
+                LocalDate.parse("2022-08-11"),
+                LocalTime.parse("13:00:00"),
+                "jin",
+                RoomEscapeService.DEFAULT_THEME
+        );
+        repository.add(reservation);
+
+        Reservation addedReservation = repository.get(0L);
+
+        Reservation expected = new Reservation(
+                0L,
+                LocalDate.parse("2022-08-11"),
+                LocalTime.parse("13:00:00"),
+                "jin",
+                RoomEscapeService.DEFAULT_THEME
+        );
+        assertThat(addedReservation).isEqualTo(expected);
+    }
 }

--- a/src/test/java/nextstep/repository/ReservationMemoryRepositoryTest.java
+++ b/src/test/java/nextstep/repository/ReservationMemoryRepositoryTest.java
@@ -2,7 +2,6 @@ package nextstep.repository;
 
 import nextstep.Reservation;
 import nextstep.Theme;
-import nextstep.service.RoomEscapeService;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -25,7 +24,7 @@ class ReservationMemoryRepositoryTest {
     }
 
     @Test
-    public void should_createAndIncreaseIndex_when_addRequestGiven() {
+    void should_createAndIncreaseIndex_when_addRequestGiven() {
         Reservation reservation = getReservationToAdd();
 
         Reservation addedReservation = repository.add(reservation);
@@ -41,7 +40,7 @@ class ReservationMemoryRepositoryTest {
     }
 
     @Test
-    public void should_findRightReservation_when_findRequestGiven() {
+    void should_findRightReservation_when_findRequestGiven() {
         repository.add(getReservationToAdd());
 
         Reservation addedReservation = repository.get(0L);
@@ -57,7 +56,7 @@ class ReservationMemoryRepositoryTest {
     }
 
     @Test
-    public void should_deleteReservation_when_deleteRequestGiven() {
+    void should_deleteReservation_when_deleteRequestGiven() {
         repository.add(getReservationToAdd());
 
         repository.delete(0L);

--- a/src/test/java/nextstep/repository/ReservationMemoryRepositoryTest.java
+++ b/src/test/java/nextstep/repository/ReservationMemoryRepositoryTest.java
@@ -1,6 +1,7 @@
 package nextstep.repository;
 
 import nextstep.Reservation;
+import nextstep.exception.DuplicateReservationException;
 import nextstep.service.RoomEscapeService;
 import org.junit.jupiter.api.Test;
 
@@ -8,6 +9,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 class ReservationMemoryRepositoryTest {
@@ -53,6 +55,14 @@ class ReservationMemoryRepositoryTest {
                 RoomEscapeService.DEFAULT_THEME
         );
         assertThat(addedReservation).isEqualTo(expected);
+    }
+
+    @Test
+    public void should_throwDuplicateDateTimeException_when_duplicateDateTimeReservationGiven() {
+        repository.add(getReservationToAdd());
+
+        assertThatThrownBy(() -> repository.add(getReservationToAdd()))
+                .isInstanceOf(DuplicateReservationException.class);
     }
 
     @Test

--- a/src/test/java/nextstep/repository/ReservationMemoryRepositoryTest.java
+++ b/src/test/java/nextstep/repository/ReservationMemoryRepositoryTest.java
@@ -13,14 +13,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ReservationMemoryRepositoryTest {
 
     private final ReservationMemoryRepository repository = new ReservationMemoryRepository();
-    @Test
-    public void should_createAndIncreaseIndex_when_addRequestGiven() {
-        Reservation reservation = new Reservation(
+
+    private Reservation getReservationToAdd() {
+        return new Reservation(
                 LocalDate.parse("2022-08-11"),
                 LocalTime.parse("13:00:00"),
                 "jin",
                 RoomEscapeService.DEFAULT_THEME
         );
+    }
+
+    @Test
+    public void should_createAndIncreaseIndex_when_addRequestGiven() {
+        Reservation reservation = getReservationToAdd();
 
         Reservation addedReservation = repository.add(reservation);
 
@@ -36,13 +41,7 @@ class ReservationMemoryRepositoryTest {
 
     @Test
     public void should_findRightReservation_when_findRequestGiven() {
-        Reservation reservation = new Reservation(
-                LocalDate.parse("2022-08-11"),
-                LocalTime.parse("13:00:00"),
-                "jin",
-                RoomEscapeService.DEFAULT_THEME
-        );
-        repository.add(reservation);
+        repository.add(getReservationToAdd());
 
         Reservation addedReservation = repository.get(0L);
 
@@ -54,5 +53,14 @@ class ReservationMemoryRepositoryTest {
                 RoomEscapeService.DEFAULT_THEME
         );
         assertThat(addedReservation).isEqualTo(expected);
+    }
+
+    @Test
+    public void should_deleteReservation_when_deleteRequestGiven() {
+        repository.add(getReservationToAdd());
+
+        repository.delete(0L);
+
+        assertThat(repository.get(0L)).isNull();
     }
 }

--- a/src/test/java/nextstep/repository/ReservationMemoryRepositoryTest.java
+++ b/src/test/java/nextstep/repository/ReservationMemoryRepositoryTest.java
@@ -1,7 +1,6 @@
 package nextstep.repository;
 
 import nextstep.Reservation;
-import nextstep.exception.DuplicateReservationException;
 import nextstep.service.RoomEscapeService;
 import org.junit.jupiter.api.Test;
 
@@ -9,7 +8,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 class ReservationMemoryRepositoryTest {
@@ -55,14 +53,6 @@ class ReservationMemoryRepositoryTest {
                 RoomEscapeService.DEFAULT_THEME
         );
         assertThat(addedReservation).isEqualTo(expected);
-    }
-
-    @Test
-    public void should_throwDuplicateDateTimeException_when_duplicateDateTimeReservationGiven() {
-        repository.add(getReservationToAdd());
-
-        assertThatThrownBy(() -> repository.add(getReservationToAdd()))
-                .isInstanceOf(DuplicateReservationException.class);
     }
 
     @Test

--- a/src/test/java/nextstep/repository/ReservationMemoryRepositoryTest.java
+++ b/src/test/java/nextstep/repository/ReservationMemoryRepositoryTest.java
@@ -15,7 +15,7 @@ class ReservationMemoryRepositoryTest {
     private final ReservationMemoryRepository repository = new ReservationMemoryRepository();
 
     private Reservation getReservationToAdd() {
-        return new Reservation(
+        return Reservation.of(
                 LocalDate.parse("2022-08-11"),
                 LocalTime.parse("13:00:00"),
                 "jin",
@@ -29,7 +29,7 @@ class ReservationMemoryRepositoryTest {
 
         Reservation addedReservation = repository.add(reservation);
 
-        Reservation expected = new Reservation(
+        Reservation expected = Reservation.of(
                 0L,
                 LocalDate.parse("2022-08-11"),
                 LocalTime.parse("13:00:00"),
@@ -45,7 +45,7 @@ class ReservationMemoryRepositoryTest {
 
         Reservation addedReservation = repository.get(0L);
 
-        Reservation expected = new Reservation(
+        Reservation expected = Reservation.of(
                 0L,
                 LocalDate.parse("2022-08-11"),
                 LocalTime.parse("13:00:00"),


### PR DESCRIPTION
제프리 안녕하세요.
방탈출 예약관리 프로그램 1, 2단계 코드입니다.

[프로젝트 스펙](https://github.com/dongjinBaek/spring-roomesacpe-reservation-kakao/blob/5ca67d880dd8e6095b706dd47f58ade5b1b42575/README.md) 입니다.

## 주요 내용
### ReservationRepository
- 1단계에서는 메모리, 2단계 콘솔 앱에서는 h2, 2단계 웹앱에서는 내장 H2 를 써야해서, 데이터 접근하는 부분을 `ReservationRepository` 인터페이스를 통하도록 하고 각 단계별 3가지 구현체를 만들었습니다.

### 3 Layer
- `Controller Layer` 에서는 응답 코드 / 헤더 / 본문 설정, 예외처리
- `Service Layer` 에서는 dto 변환, 데이터 요청쿼리 조립
- `Repository Layer` 에서는 데이터 접근을 하도록 나눴습니다.

## 고민인 점
### Service와 Controller 사이의 경계
- `RequestDto` 객체를 `Controller`에서 `Service`로 전달하고, `Service`에서 `Reservation` 객체로 변환해 사용하도록 했습니다.
- `Service`의 리턴 타입도 인자 타입과 통일성을 위해 `ResponseDto` 객체로 만들었는데요, `Service`를 사용하는 클라이언트가 콘솔앱, 웹앱 컨트롤러 두 가지가 있는데 하나의 `Response` 객체로 리턴해줘도 되나? 가 고민이었습니다.
- Dto - Entity 변환 로직도 Dto에 넣어두었는데, 제프리는 선호하시는 위치가 있는지 궁금합니다.

### Controller 리턴 타입
- 정상 응답에서는 `ResponseEntity<Dto>`, 에러 시에는 `ResponseEntity<String(메시지)>`를 `Controller`에서 리턴하도록 했는데요, 어떤 타입을 반환하면 좋을지(특히 에러) 고민이었습니다.

### 같은 타입의 여러 빈
- `ReservationRepository` 타입의 빈으로 1단계에서 `ReservationMemoryRepository` 를 만들었는데, 2단계에서 같은 인터페이스를 구현한 `ReservationH2JdbcTemplateRepository` 빈을 새로 만들면서 같은 타입의 빈이 두 개 생기면서 자동주입이 실패하는 오류가 있었습니다.
- 일단은 기존 빈의 `@Repository` 어노테이션을 삭제하는  식으로 진행했는데, 보통 이럴 때 어떻게 하는지 궁금합니다.