### PR TITLE
[herbi.sf8] 방탈출 예약 관리 step3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,30 +11,52 @@
 - [x] 콘솔 애플리케이션에 데이터베이스를 적용한다.
 - [x] 웹 애플리케이션에 데이터베이스를 적용한다.
 
+3단계 
+- [x] 테마 관리 기능 추가
+- [x] 테마를 관리하는 테이블을 추가한다.
+- [x] 콘솔 애플리케이션과 웹 애플리케이션의 로직의 중복을 제거한다.
+
 ## 프로젝트 구조
 - Controller
   - ReservationController
+  - ThemeController
 - Service
   - ReservationService
+  - ThemeService
 - Repository
   - ReservationRepository (인터페이스)
   - MemoryReservationRepository (인메모리 리스트)
   - JdbcReservationRepository (H2 DB 연동)
+  - ThemeRepository
+  - JdbcThemeRepository
 - Entity
   - Reservation
   - Theme
+- Dto
+  - ReservationRequest
+  - ReservationResponse
+  - ThemeRequest
+  - ThemeResponse
 - Exception
-  - CreateReservationException
-
+  - RoomEscapeException
+  - RoomEscapeExceptionCode
+  
 ## 테스트
 - ReservationControllerTest
+- ReservationServiceTest
 - ReservationRepositoryTest
+- ThemeControllerTest
+- ThemeServiceTest
+- ThemeRepositoryTest
 
 ## API 구조
-| URI                | Method | 반환값         | 비고                                                               |
-|--------------------|--------|-------------|------------------------------------------------------------------|
-| /reservations      | POST   | Reservation | Reservation 객체를 인자로 받아 id 생성후 Reservation 객체를 새로 만들어 DB에 저장 후 반환 |
-| /reservations      | DELETE | 204         | 예약 테이블 전체 삭제                                                     |
-| /reservations/{id} | GET    | Reservation | 해당 id의 예약 객체 반환                                                  |
-| /reservations/{id} | DELETE | 204         | 해당 id의 예약 삭제                                                     |
-
+| URI                | Method | 반환값                      | 비고                                                                                               |
+|--------------------|--------|--------------------------|--------------------------------------------------------------------------------------------------|
+| /reservations      | POST   | 201 / 400                | Reservation 객체를 인자로 받아 id 생성후 Reservation 객체를 새로 만들어 DB에 저장 후 반환, 이미 해당 시간에 예약이 존재하면 bad request |
+| /reservations      | DELETE | 204                      | 예약 테이블 전체 삭제                                                                                     |
+| /reservations/{id} | GET    | ReservationResponse /400 | 해당 id의 예약 객체 반환, 없으면 bad reqeust                                                                 |
+| /reservations/{id} | DELETE | 204                      | 해당 id의 예약 삭제                                                                                     |
+| /themes            | POST   | 201                      | Theme 추가후 /themes/{id}로 이동                                                                       |
+| /themes            | GET    | List<ThemeResponse>      | 저장된 테마 리스트 반환                                                                                    |
+| /themes/{id}       | GET    | ThemeResponse / 400      | 해당 id를 가진 테마 반환, 없으면 bad request                                                                 |
+| /themes/{id}       | DELETE | 204 / 400                | 해당 id의 테마 삭제, 테마가 존재하지 않으면 bad request                                                           |

--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,15 @@ version '1.0-SNAPSHOT'
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.projectlombok:lombok'
+    annotationProcessor('org.projectlombok:lombok')
+
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
     testImplementation 'io.rest-assured:rest-assured:4.4.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    testImplementation 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     runtimeOnly 'com.h2database:h2'
 }

--- a/src/main/java/nextstep/reservation/RoomEscapeApplication.java
+++ b/src/main/java/nextstep/reservation/RoomEscapeApplication.java
@@ -1,98 +1,99 @@
-//package nextstep.reservation;
-//
-//import nextstep.reservation.entity.Reservation;
-//import nextstep.reservation.entity.Theme;
-//import nextstep.reservation.repository.JdbcReservationRepository;
-//import nextstep.reservation.service.ReservationService;
-//import org.springframework.jdbc.core.JdbcTemplate;
-//import org.springframework.jdbc.datasource.DriverManagerDataSource;
-//
-//import javax.sql.DataSource;
-//import java.time.LocalDate;
-//import java.time.LocalTime;
-//import java.util.Scanner;
-//
-//public class RoomEscapeApplication {
-//    private static final String ADD = "add";
-//    private static final String FIND = "find";
-//    private static final String DELETE = "delete";
-//    private static final String QUIT = "quit";
-//
-//    public static void main(String[] args) {
-//        Scanner scanner = new Scanner(System.in);
-//        ReservationService reservationService = new ReservationService(new JdbcReservationRepository(new JdbcTemplate(dataSource())));
-//
-//
-//        Theme theme = new Theme("워너고홈", "병맛 어드벤처 회사 코믹물", 29_000);
-//
-//        while (true) {
-//            System.out.println();
-//            System.out.println("### 명령어를 입력하세요. ###");
-//            System.out.println("- 예약하기: add {date},{time},{name} ex) add 2022-08-11,13:00,류성현");
-//            System.out.println("- 예약조회: find {id} ex) find 1");
-//            System.out.println("- 예약취소: delete {id} ex) delete 1");
-//            System.out.println("- 종료: quit");
-//
-//            String input = scanner.nextLine();
-//            if (input.startsWith(ADD)) {
-//                String params = input.split(" ")[1];
-//
-//                String date = params.split(",")[0];
-//                String time = params.split(",")[1];
-//                String name = params.split(",")[2];
-//
-//                Reservation reservation = new Reservation(
-//                        null,
-//                        LocalDate.parse(date),
-//                        LocalTime.parse(time + ":00"),
-//                        name,
-//                        theme
-//                );
-//                Reservation createReservation = reservationService.create(reservation);
-//
-//                System.out.println("예약이 등록되었습니다.");
-//                System.out.println("예약 번호: " + createReservation.getId());
-//                System.out.println("예약 날짜: " + createReservation.getDate());
-//                System.out.println("예약 시간: " + createReservation.getTime());
-//                System.out.println("예약자 이름: " + createReservation.getName());
-//            }
-//
-//            if (input.startsWith(FIND)) {
-//                String params = input.split(" ")[1];
-//                long id = Long.parseLong(params.split(",")[0]);
-//                Reservation reservation = reservationService.findById(id);
-//
-//                System.out.println("예약 번호: " + reservation.getId());
-//                System.out.println("예약 날짜: " + reservation.getDate());
-//                System.out.println("예약 시간: " + reservation.getTime());
-//                System.out.println("예약자 이름: " + reservation.getName());
+package nextstep.reservation;
+
+import nextstep.reservation.entity.Reservation;
+import nextstep.reservation.entity.Theme;
+import nextstep.reservation.repository.JdbcReservationRepository;
+import nextstep.reservation.service.ReservationService;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import javax.sql.DataSource;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Scanner;
+
+public class RoomEscapeApplication {
+    private static final String ADD = "add";
+    private static final String FIND = "find";
+    private static final String DELETE = "delete";
+    private static final String QUIT = "quit";
+
+    public static void main(String[] args) {
+        Scanner scanner = new Scanner(System.in);
+        ReservationService reservationService = new ReservationService(new JdbcReservationRepository(new JdbcTemplate(dataSource())));
+
+
+        Theme theme = new Theme(1L, "워너고홈", "병맛 어드벤처 회사 코믹물", 29_000);
+
+        while (true) {
+            System.out.println();
+            System.out.println("### 명령어를 입력하세요. ###");
+            System.out.println("- 예약하기: add {date},{time},{name} ex) add 2022-08-11,13:00,류성현");
+            System.out.println("- 예약조회: find {id} ex) find 1");
+            System.out.println("- 예약취소: delete {id} ex) delete 1");
+            System.out.println("- 종료: quit");
+
+            String input = scanner.nextLine();
+            if (input.startsWith(ADD)) {
+                String params = input.split(" ")[1];
+
+                String date = params.split(",")[0];
+                String time = params.split(",")[1];
+                String name = params.split(",")[2];
+
+                Reservation reservation = new Reservation(
+                        null,
+                        LocalDate.parse(date),
+                        LocalTime.parse(time + ":00"),
+                        name,
+                        theme.getId()
+                );
+                Reservation createReservation = reservationService.create(reservation);
+
+                System.out.println("예약이 등록되었습니다.");
+                System.out.println("예약 번호: " + createReservation.getId());
+                System.out.println("예약 날짜: " + createReservation.getDate());
+                System.out.println("예약 시간: " + createReservation.getTime());
+                System.out.println("예약자 이름: " + createReservation.getName());
+            }
+
+            if (input.startsWith(FIND)) {
+                String params = input.split(" ")[1];
+                long id = Long.parseLong(params.split(",")[0]);
+                Reservation reservation = reservationService.findById(id);
+
+                System.out.println("예약 번호: " + reservation.getId());
+                System.out.println("예약 날짜: " + reservation.getDate());
+                System.out.println("예약 시간: " + reservation.getTime());
+                System.out.println("예약자 이름: " + reservation.getName());
+                System.out.println("예약 테마 ID: " + reservation.getThemeId());
 //                System.out.println("예약 테마 이름: " + reservation.getTheme().getName());
 //                System.out.println("예약 테마 설명: " + reservation.getTheme().getDesc());
 //                System.out.println("예약 테마 가격: " + reservation.getTheme().getPrice());
-//            }
-//
-//            if (input.startsWith(DELETE)) {
-//                String params = input.split(" ")[1];
-//
-//                long id = Long.parseLong(params.split(",")[0]);
-//
-//                if (reservationService.delete(id)) {
-//                    System.out.println("예약이 취소되었습니다.");
-//                }
-//            }
-//
-//            if (input.equals(QUIT)) {
-//                break;
-//            }
-//        }
-//    }
-//
-//    public static DataSource dataSource() {
-//        DriverManagerDataSource dataSource = new DriverManagerDataSource();
-//        dataSource.setUsername("sa");
-//        dataSource.setPassword("");
-//        dataSource.setDriverClassName("org.h2.Driver");
-//        dataSource.setUrl("jdbc:h2:~/test");
-//        return dataSource;
-//    }
-//}
+            }
+
+            if (input.startsWith(DELETE)) {
+                String params = input.split(" ")[1];
+
+                long id = Long.parseLong(params.split(",")[0]);
+
+                if (reservationService.delete(id)) {
+                    System.out.println("예약이 취소되었습니다.");
+                }
+            }
+
+            if (input.equals(QUIT)) {
+                break;
+            }
+        }
+    }
+
+    public static DataSource dataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:~/test");
+        return dataSource;
+    }
+}

--- a/src/main/java/nextstep/reservation/RoomEscapeApplication.java
+++ b/src/main/java/nextstep/reservation/RoomEscapeApplication.java
@@ -1,98 +1,98 @@
-package nextstep.reservation;
-
-import nextstep.reservation.entity.Reservation;
-import nextstep.reservation.entity.Theme;
-import nextstep.reservation.repository.JdbcReservationRepository;
-import nextstep.reservation.service.ReservationService;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DriverManagerDataSource;
-
-import javax.sql.DataSource;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.Scanner;
-
-public class RoomEscapeApplication {
-    private static final String ADD = "add";
-    private static final String FIND = "find";
-    private static final String DELETE = "delete";
-    private static final String QUIT = "quit";
-
-    public static void main(String[] args) {
-        Scanner scanner = new Scanner(System.in);
-        ReservationService reservationService = new ReservationService(new JdbcReservationRepository(new JdbcTemplate(dataSource())));
-
-
-        Theme theme = new Theme("워너고홈", "병맛 어드벤처 회사 코믹물", 29_000);
-
-        while (true) {
-            System.out.println();
-            System.out.println("### 명령어를 입력하세요. ###");
-            System.out.println("- 예약하기: add {date},{time},{name} ex) add 2022-08-11,13:00,류성현");
-            System.out.println("- 예약조회: find {id} ex) find 1");
-            System.out.println("- 예약취소: delete {id} ex) delete 1");
-            System.out.println("- 종료: quit");
-
-            String input = scanner.nextLine();
-            if (input.startsWith(ADD)) {
-                String params = input.split(" ")[1];
-
-                String date = params.split(",")[0];
-                String time = params.split(",")[1];
-                String name = params.split(",")[2];
-
-                Reservation reservation = new Reservation(
-                        null,
-                        LocalDate.parse(date),
-                        LocalTime.parse(time + ":00"),
-                        name,
-                        theme
-                );
-                Reservation createReservation = reservationService.create(reservation);
-
-                System.out.println("예약이 등록되었습니다.");
-                System.out.println("예약 번호: " + createReservation.getId());
-                System.out.println("예약 날짜: " + createReservation.getDate());
-                System.out.println("예약 시간: " + createReservation.getTime());
-                System.out.println("예약자 이름: " + createReservation.getName());
-            }
-
-            if (input.startsWith(FIND)) {
-                String params = input.split(" ")[1];
-                long id = Long.parseLong(params.split(",")[0]);
-                Reservation reservation = reservationService.findById(id);
-
-                System.out.println("예약 번호: " + reservation.getId());
-                System.out.println("예약 날짜: " + reservation.getDate());
-                System.out.println("예약 시간: " + reservation.getTime());
-                System.out.println("예약자 이름: " + reservation.getName());
-                System.out.println("예약 테마 이름: " + reservation.getTheme().getName());
-                System.out.println("예약 테마 설명: " + reservation.getTheme().getDesc());
-                System.out.println("예약 테마 가격: " + reservation.getTheme().getPrice());
-            }
-
-            if (input.startsWith(DELETE)) {
-                String params = input.split(" ")[1];
-
-                long id = Long.parseLong(params.split(",")[0]);
-
-                if (reservationService.delete(id)) {
-                    System.out.println("예약이 취소되었습니다.");
-                }
-            }
-
-            if (input.equals(QUIT)) {
-                break;
-            }
-        }
-    }
-
-    public static DataSource dataSource() {
-        DriverManagerDataSource dataSource = new DriverManagerDataSource();
-        dataSource.setUsername("sa");
-        dataSource.setPassword("");
-        dataSource.setDriverClassName("org.h2.Driver");
-        dataSource.setUrl("jdbc:h2:~/test");
-        return dataSource;
-    }
-}
+//package nextstep.reservation;
+//
+//import nextstep.reservation.entity.Reservation;
+//import nextstep.reservation.entity.Theme;
+//import nextstep.reservation.repository.JdbcReservationRepository;
+//import nextstep.reservation.service.ReservationService;
+//import org.springframework.jdbc.core.JdbcTemplate;
+//import org.springframework.jdbc.datasource.DriverManagerDataSource;
+//
+//import javax.sql.DataSource;
+//import java.time.LocalDate;
+//import java.time.LocalTime;
+//import java.util.Scanner;
+//
+//public class RoomEscapeApplication {
+//    private static final String ADD = "add";
+//    private static final String FIND = "find";
+//    private static final String DELETE = "delete";
+//    private static final String QUIT = "quit";
+//
+//    public static void main(String[] args) {
+//        Scanner scanner = new Scanner(System.in);
+//        ReservationService reservationService = new ReservationService(new JdbcReservationRepository(new JdbcTemplate(dataSource())));
+//
+//
+//        Theme theme = new Theme("워너고홈", "병맛 어드벤처 회사 코믹물", 29_000);
+//
+//        while (true) {
+//            System.out.println();
+//            System.out.println("### 명령어를 입력하세요. ###");
+//            System.out.println("- 예약하기: add {date},{time},{name} ex) add 2022-08-11,13:00,류성현");
+//            System.out.println("- 예약조회: find {id} ex) find 1");
+//            System.out.println("- 예약취소: delete {id} ex) delete 1");
+//            System.out.println("- 종료: quit");
+//
+//            String input = scanner.nextLine();
+//            if (input.startsWith(ADD)) {
+//                String params = input.split(" ")[1];
+//
+//                String date = params.split(",")[0];
+//                String time = params.split(",")[1];
+//                String name = params.split(",")[2];
+//
+//                Reservation reservation = new Reservation(
+//                        null,
+//                        LocalDate.parse(date),
+//                        LocalTime.parse(time + ":00"),
+//                        name,
+//                        theme
+//                );
+//                Reservation createReservation = reservationService.create(reservation);
+//
+//                System.out.println("예약이 등록되었습니다.");
+//                System.out.println("예약 번호: " + createReservation.getId());
+//                System.out.println("예약 날짜: " + createReservation.getDate());
+//                System.out.println("예약 시간: " + createReservation.getTime());
+//                System.out.println("예약자 이름: " + createReservation.getName());
+//            }
+//
+//            if (input.startsWith(FIND)) {
+//                String params = input.split(" ")[1];
+//                long id = Long.parseLong(params.split(",")[0]);
+//                Reservation reservation = reservationService.findById(id);
+//
+//                System.out.println("예약 번호: " + reservation.getId());
+//                System.out.println("예약 날짜: " + reservation.getDate());
+//                System.out.println("예약 시간: " + reservation.getTime());
+//                System.out.println("예약자 이름: " + reservation.getName());
+//                System.out.println("예약 테마 이름: " + reservation.getTheme().getName());
+//                System.out.println("예약 테마 설명: " + reservation.getTheme().getDesc());
+//                System.out.println("예약 테마 가격: " + reservation.getTheme().getPrice());
+//            }
+//
+//            if (input.startsWith(DELETE)) {
+//                String params = input.split(" ")[1];
+//
+//                long id = Long.parseLong(params.split(",")[0]);
+//
+//                if (reservationService.delete(id)) {
+//                    System.out.println("예약이 취소되었습니다.");
+//                }
+//            }
+//
+//            if (input.equals(QUIT)) {
+//                break;
+//            }
+//        }
+//    }
+//
+//    public static DataSource dataSource() {
+//        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+//        dataSource.setUsername("sa");
+//        dataSource.setPassword("");
+//        dataSource.setDriverClassName("org.h2.Driver");
+//        dataSource.setUrl("jdbc:h2:~/test");
+//        return dataSource;
+//    }
+//}

--- a/src/main/java/nextstep/reservation/RoomEscapeApplication.java
+++ b/src/main/java/nextstep/reservation/RoomEscapeApplication.java
@@ -48,7 +48,7 @@ public class RoomEscapeApplication {
                         name,
                         theme.getId()
                 );
-                Reservation createReservation = reservationService.create(reservation);
+                Reservation createReservation = reservationService.registerReservation(reservation);
 
                 System.out.println("예약이 등록되었습니다.");
                 System.out.println("예약 번호: " + createReservation.getId());

--- a/src/main/java/nextstep/reservation/RoomEscapeApplication.java
+++ b/src/main/java/nextstep/reservation/RoomEscapeApplication.java
@@ -1,99 +1,157 @@
-//package nextstep.reservation;
-//
-//import nextstep.reservation.entity.Reservation;
-//import nextstep.reservation.entity.Theme;
-//import nextstep.reservation.repository.JdbcReservationRepository;
-//import nextstep.reservation.service.ReservationService;
-//import org.springframework.jdbc.core.JdbcTemplate;
-//import org.springframework.jdbc.datasource.DriverManagerDataSource;
-//
-//import javax.sql.DataSource;
-//import java.time.LocalDate;
-//import java.time.LocalTime;
-//import java.util.Scanner;
-//
-//public class RoomEscapeApplication {
-//    private static final String ADD = "add";
-//    private static final String FIND = "find";
-//    private static final String DELETE = "delete";
-//    private static final String QUIT = "quit";
-//
-//    public static void main(String[] args) {
-//        Scanner scanner = new Scanner(System.in);
-//        ReservationService reservationService = new ReservationService(new JdbcReservationRepository(new JdbcTemplate(dataSource())));
-//
-//
-//        Theme theme = new Theme(1L, "워너고홈", "병맛 어드벤처 회사 코믹물", 29_000);
-//
-//        while (true) {
-//            System.out.println();
-//            System.out.println("### 명령어를 입력하세요. ###");
-//            System.out.println("- 예약하기: add {date},{time},{name} ex) add 2022-08-11,13:00,류성현");
-//            System.out.println("- 예약조회: find {id} ex) find 1");
-//            System.out.println("- 예약취소: delete {id} ex) delete 1");
-//            System.out.println("- 종료: quit");
-//
-//            String input = scanner.nextLine();
-//            if (input.startsWith(ADD)) {
-//                String params = input.split(" ")[1];
-//
-//                String date = params.split(",")[0];
-//                String time = params.split(",")[1];
-//                String name = params.split(",")[2];
-//
-//                Reservation reservation = new Reservation(
-//                        null,
-//                        LocalDate.parse(date),
-//                        LocalTime.parse(time + ":00"),
-//                        name,
-//                        theme.getId()
-//                );
-//                Reservation createReservation = reservationService.registerReservation(reservation);
-//
-//                System.out.println("예약이 등록되었습니다.");
-//                System.out.println("예약 번호: " + createReservation.getId());
-//                System.out.println("예약 날짜: " + createReservation.getDate());
-//                System.out.println("예약 시간: " + createReservation.getTime());
-//                System.out.println("예약자 이름: " + createReservation.getName());
-//            }
-//
-//            if (input.startsWith(FIND)) {
-//                String params = input.split(" ")[1];
-//                long id = Long.parseLong(params.split(",")[0]);
-//                Reservation reservation = reservationService.findById(id);
-//
-//                System.out.println("예약 번호: " + reservation.getId());
-//                System.out.println("예약 날짜: " + reservation.getDate());
-//                System.out.println("예약 시간: " + reservation.getTime());
-//                System.out.println("예약자 이름: " + reservation.getName());
-//                System.out.println("예약 테마 ID: " + reservation.getThemeId());
-////                System.out.println("예약 테마 이름: " + reservation.getTheme().getName());
-////                System.out.println("예약 테마 설명: " + reservation.getTheme().getDesc());
-////                System.out.println("예약 테마 가격: " + reservation.getTheme().getPrice());
-//            }
-//
-//            if (input.startsWith(DELETE)) {
-//                String params = input.split(" ")[1];
-//
-//                long id = Long.parseLong(params.split(",")[0]);
-//
-//                if (reservationService.delete(id)) {
-//                    System.out.println("예약이 취소되었습니다.");
-//                }
-//            }
-//
-//            if (input.equals(QUIT)) {
-//                break;
-//            }
-//        }
-//    }
-//
-//    public static DataSource dataSource() {
-//        DriverManagerDataSource dataSource = new DriverManagerDataSource();
-//        dataSource.setUsername("sa");
-//        dataSource.setPassword("");
-//        dataSource.setDriverClassName("org.h2.Driver");
-//        dataSource.setUrl("jdbc:h2:~/test");
-//        return dataSource;
-//    }
-//}
+package nextstep.reservation;
+
+import nextstep.reservation.dto.ReservationRequest;
+import nextstep.reservation.dto.ReservationResponse;
+import nextstep.reservation.dto.ThemeRequest;
+import nextstep.reservation.dto.ThemeResponse;
+import nextstep.reservation.exception.RoomEscapeException;
+import nextstep.reservation.repository.JdbcReservationRepository;
+import nextstep.reservation.repository.JdbcThemeRepository;
+import nextstep.reservation.service.ReservationService;
+import nextstep.reservation.service.ThemeService;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import javax.sql.DataSource;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Scanner;
+
+public class RoomEscapeApplication {
+    private static final String ADD = "add";
+    private static final String FIND = "find";
+    private static final String FIND_ALL = "findAll";
+    private static final String DELETE = "delete";
+    private static final String QUIT = "quit";
+
+    public static void main(String[] args) {
+        Scanner scanner = new Scanner(System.in);
+        ThemeService themeService = new ThemeService(new JdbcThemeRepository(new JdbcTemplate(dataSource())));
+        ReservationService reservationService = new ReservationService(new JdbcReservationRepository(new JdbcTemplate(dataSource())), themeService);
+
+
+        while (true) {
+            System.out.println();
+            System.out.println("### 명령어를 입력하세요. ###");
+            System.out.println("- 예약하기: add reservation {date},{time},{name},{themeId} ex) add reservation 2022-08-11,13:00,류성현,1");
+            System.out.println("- 예약조회: find {id} ex) find 1");
+            System.out.println("- 예약취소: delete {id} ex) delete 1");
+            System.out.println("- 테마추가하기: add theme {name},{desc},{price} ex) add theme 호러,매우무서운,25000");
+            System.out.println("- 테마전체조회하기: findAll theme");
+            System.out.println("- 종료: quit");
+
+            String input = scanner.nextLine();
+            if (input.startsWith(ADD)) {
+                String target = input.split(" ")[1];
+                if (target.equals("reservation")) {
+                    String params = input.split(" ")[2];
+
+                    String date = params.split(",")[0];
+                    String time = params.split(",")[1];
+                    String name = params.split(",")[2];
+                    String themeId = params.split(",")[3];
+
+                    ReservationRequest reservationRequest = ReservationRequest.builder()
+                            .date(LocalDate.parse(date))
+                            .time(LocalTime.parse(time + ":00"))
+                            .name(name)
+                            .themeId(Long.valueOf(themeId))
+                            .build();
+                    try {
+                        ReservationResponse createdReservation = reservationService.registerReservation(reservationRequest);
+                        System.out.println("예약이 등록되었습니다.");
+                        System.out.println("예약 번호: " + createdReservation.getId());
+                        System.out.println("예약 날짜: " + createdReservation.getDate());
+                        System.out.println("예약 시간: " + createdReservation.getTime());
+                        System.out.println("예약자 이름: " + createdReservation.getName());
+                        System.out.println("테마 번호: " + createdReservation.getThemeId());
+                        System.out.println("테마 이름: " + createdReservation.getThemeName());
+                        System.out.println("테마 설명: " + createdReservation.getThemeDesc());
+                        System.out.println("테마 가격: " + createdReservation.getThemePrice());
+                    } catch (RoomEscapeException e) {
+                        System.out.println(e.getMessage());
+                    }
+                } else if (target.equals("theme")) {
+                    String params = input.split(" ")[2];
+
+                    String name = params.split(",")[0];
+                    String desc = params.split(",")[1];
+                    String price = params.split(",")[2];
+
+                    ThemeRequest themeRequest = ThemeRequest.builder()
+                            .name(name)
+                            .desc(desc)
+                            .price(Integer.valueOf(price))
+                            .build();
+
+                    try {
+
+                        ThemeResponse themeResponse = themeService.registerTheme(themeRequest);
+
+                        System.out.println("테마가 등록되었습니다.");
+                        System.out.println("테마 번호: " + themeResponse.getId());
+                        System.out.println("테마 이름: " + themeResponse.getName());
+                        System.out.println("테마 설명: " + themeResponse.getDesc());
+                        System.out.println("테마 가격: " + themeResponse.getPrice());
+                    } catch (RoomEscapeException e) {
+                        System.out.println(e.getMessage());
+                    }
+                }
+            }
+
+            if (input.split(" ")[0].equals(FIND)) {
+                String params = input.split(" ")[1];
+                long id = Long.parseLong(params.split(",")[0]);
+                try {
+                    ReservationResponse reservationResponse = reservationService.findById(id);
+
+                    System.out.println("예약 번호: " + reservationResponse.getId());
+                    System.out.println("예약 날짜: " + reservationResponse.getDate());
+                    System.out.println("예약 시간: " + reservationResponse.getTime());
+                    System.out.println("예약자 이름: " + reservationResponse.getName());
+                    System.out.println("예약 테마 ID: " + reservationResponse.getThemeId());
+                    System.out.println("예약 테마 이름: " + reservationResponse.getThemeName());
+                    System.out.println("예약 테마 설명: " + reservationResponse.getThemeDesc());
+                    System.out.println("예약 테마 가격: " + reservationResponse.getThemePrice());
+                } catch (RoomEscapeException e) {
+                    System.out.println(e.getMessage());
+                }
+            }
+
+            if (input.startsWith(FIND_ALL)) {
+                List<ThemeResponse> themes = themeService.findAll();
+                for (ThemeResponse themeResponse : themes) {
+                    System.out.println("예약 테마 ID: " + themeResponse.getId());
+                    System.out.println("예약 테마 이름: " + themeResponse.getName());
+                    System.out.println("예약 테마 설명: " + themeResponse.getDesc());
+                    System.out.println("예약 테마 가격: " + themeResponse.getPrice());
+                    System.out.println();
+                }
+            }
+
+            if (input.startsWith(DELETE)) {
+                String params = input.split(" ")[1];
+
+                long id = Long.parseLong(params.split(",")[0]);
+
+                if (reservationService.delete(id)) {
+                    System.out.println("예약이 취소되었습니다.");
+                }
+            }
+
+            if (input.equals(QUIT)) {
+                break;
+            }
+        }
+    }
+
+    public static DataSource dataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:~/test");
+        return dataSource;
+    }
+}

--- a/src/main/java/nextstep/reservation/RoomEscapeApplication.java
+++ b/src/main/java/nextstep/reservation/RoomEscapeApplication.java
@@ -65,9 +65,9 @@ public class RoomEscapeApplication {
                         System.out.println("예약 날짜: " + createdReservation.getDate());
                         System.out.println("예약 시간: " + createdReservation.getTime());
                         System.out.println("예약자 이름: " + createdReservation.getName());
-                        System.out.println("테마 이름: " + createdReservation.getThemeName());
-                        System.out.println("테마 설명: " + createdReservation.getThemeDesc());
-                        System.out.println("테마 가격: " + createdReservation.getThemePrice());
+                        System.out.println("테마 이름: " + createdReservation.getThemeResponse().getName());
+                        System.out.println("테마 설명: " + createdReservation.getThemeResponse().getDesc());
+                        System.out.println("테마 가격: " + createdReservation.getThemeResponse().getPrice());
                     } catch (RoomEscapeException e) {
                         System.out.println(e.getMessage());
                     }
@@ -109,9 +109,9 @@ public class RoomEscapeApplication {
                     System.out.println("예약 날짜: " + reservationResponse.getDate());
                     System.out.println("예약 시간: " + reservationResponse.getTime());
                     System.out.println("예약자 이름: " + reservationResponse.getName());
-                    System.out.println("예약 테마 이름: " + reservationResponse.getThemeName());
-                    System.out.println("예약 테마 설명: " + reservationResponse.getThemeDesc());
-                    System.out.println("예약 테마 가격: " + reservationResponse.getThemePrice());
+                    System.out.println("예약 테마 이름: " + reservationResponse.getThemeResponse().getName());
+                    System.out.println("예약 테마 설명: " + reservationResponse.getThemeResponse().getDesc());
+                    System.out.println("예약 테마 가격: " + reservationResponse.getThemeResponse().getPrice());
                 } catch (RoomEscapeException e) {
                     System.out.println(e.getMessage());
                 }

--- a/src/main/java/nextstep/reservation/RoomEscapeApplication.java
+++ b/src/main/java/nextstep/reservation/RoomEscapeApplication.java
@@ -65,7 +65,6 @@ public class RoomEscapeApplication {
                         System.out.println("예약 날짜: " + createdReservation.getDate());
                         System.out.println("예약 시간: " + createdReservation.getTime());
                         System.out.println("예약자 이름: " + createdReservation.getName());
-                        System.out.println("테마 번호: " + createdReservation.getThemeId());
                         System.out.println("테마 이름: " + createdReservation.getThemeName());
                         System.out.println("테마 설명: " + createdReservation.getThemeDesc());
                         System.out.println("테마 가격: " + createdReservation.getThemePrice());
@@ -110,7 +109,6 @@ public class RoomEscapeApplication {
                     System.out.println("예약 날짜: " + reservationResponse.getDate());
                     System.out.println("예약 시간: " + reservationResponse.getTime());
                     System.out.println("예약자 이름: " + reservationResponse.getName());
-                    System.out.println("예약 테마 ID: " + reservationResponse.getThemeId());
                     System.out.println("예약 테마 이름: " + reservationResponse.getThemeName());
                     System.out.println("예약 테마 설명: " + reservationResponse.getThemeDesc());
                     System.out.println("예약 테마 가격: " + reservationResponse.getThemePrice());

--- a/src/main/java/nextstep/reservation/RoomEscapeApplication.java
+++ b/src/main/java/nextstep/reservation/RoomEscapeApplication.java
@@ -1,99 +1,99 @@
-package nextstep.reservation;
-
-import nextstep.reservation.entity.Reservation;
-import nextstep.reservation.entity.Theme;
-import nextstep.reservation.repository.JdbcReservationRepository;
-import nextstep.reservation.service.ReservationService;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DriverManagerDataSource;
-
-import javax.sql.DataSource;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.Scanner;
-
-public class RoomEscapeApplication {
-    private static final String ADD = "add";
-    private static final String FIND = "find";
-    private static final String DELETE = "delete";
-    private static final String QUIT = "quit";
-
-    public static void main(String[] args) {
-        Scanner scanner = new Scanner(System.in);
-        ReservationService reservationService = new ReservationService(new JdbcReservationRepository(new JdbcTemplate(dataSource())));
-
-
-        Theme theme = new Theme(1L, "워너고홈", "병맛 어드벤처 회사 코믹물", 29_000);
-
-        while (true) {
-            System.out.println();
-            System.out.println("### 명령어를 입력하세요. ###");
-            System.out.println("- 예약하기: add {date},{time},{name} ex) add 2022-08-11,13:00,류성현");
-            System.out.println("- 예약조회: find {id} ex) find 1");
-            System.out.println("- 예약취소: delete {id} ex) delete 1");
-            System.out.println("- 종료: quit");
-
-            String input = scanner.nextLine();
-            if (input.startsWith(ADD)) {
-                String params = input.split(" ")[1];
-
-                String date = params.split(",")[0];
-                String time = params.split(",")[1];
-                String name = params.split(",")[2];
-
-                Reservation reservation = new Reservation(
-                        null,
-                        LocalDate.parse(date),
-                        LocalTime.parse(time + ":00"),
-                        name,
-                        theme.getId()
-                );
-                Reservation createReservation = reservationService.registerReservation(reservation);
-
-                System.out.println("예약이 등록되었습니다.");
-                System.out.println("예약 번호: " + createReservation.getId());
-                System.out.println("예약 날짜: " + createReservation.getDate());
-                System.out.println("예약 시간: " + createReservation.getTime());
-                System.out.println("예약자 이름: " + createReservation.getName());
-            }
-
-            if (input.startsWith(FIND)) {
-                String params = input.split(" ")[1];
-                long id = Long.parseLong(params.split(",")[0]);
-                Reservation reservation = reservationService.findById(id);
-
-                System.out.println("예약 번호: " + reservation.getId());
-                System.out.println("예약 날짜: " + reservation.getDate());
-                System.out.println("예약 시간: " + reservation.getTime());
-                System.out.println("예약자 이름: " + reservation.getName());
-                System.out.println("예약 테마 ID: " + reservation.getThemeId());
-//                System.out.println("예약 테마 이름: " + reservation.getTheme().getName());
-//                System.out.println("예약 테마 설명: " + reservation.getTheme().getDesc());
-//                System.out.println("예약 테마 가격: " + reservation.getTheme().getPrice());
-            }
-
-            if (input.startsWith(DELETE)) {
-                String params = input.split(" ")[1];
-
-                long id = Long.parseLong(params.split(",")[0]);
-
-                if (reservationService.delete(id)) {
-                    System.out.println("예약이 취소되었습니다.");
-                }
-            }
-
-            if (input.equals(QUIT)) {
-                break;
-            }
-        }
-    }
-
-    public static DataSource dataSource() {
-        DriverManagerDataSource dataSource = new DriverManagerDataSource();
-        dataSource.setUsername("sa");
-        dataSource.setPassword("");
-        dataSource.setDriverClassName("org.h2.Driver");
-        dataSource.setUrl("jdbc:h2:~/test");
-        return dataSource;
-    }
-}
+//package nextstep.reservation;
+//
+//import nextstep.reservation.entity.Reservation;
+//import nextstep.reservation.entity.Theme;
+//import nextstep.reservation.repository.JdbcReservationRepository;
+//import nextstep.reservation.service.ReservationService;
+//import org.springframework.jdbc.core.JdbcTemplate;
+//import org.springframework.jdbc.datasource.DriverManagerDataSource;
+//
+//import javax.sql.DataSource;
+//import java.time.LocalDate;
+//import java.time.LocalTime;
+//import java.util.Scanner;
+//
+//public class RoomEscapeApplication {
+//    private static final String ADD = "add";
+//    private static final String FIND = "find";
+//    private static final String DELETE = "delete";
+//    private static final String QUIT = "quit";
+//
+//    public static void main(String[] args) {
+//        Scanner scanner = new Scanner(System.in);
+//        ReservationService reservationService = new ReservationService(new JdbcReservationRepository(new JdbcTemplate(dataSource())));
+//
+//
+//        Theme theme = new Theme(1L, "워너고홈", "병맛 어드벤처 회사 코믹물", 29_000);
+//
+//        while (true) {
+//            System.out.println();
+//            System.out.println("### 명령어를 입력하세요. ###");
+//            System.out.println("- 예약하기: add {date},{time},{name} ex) add 2022-08-11,13:00,류성현");
+//            System.out.println("- 예약조회: find {id} ex) find 1");
+//            System.out.println("- 예약취소: delete {id} ex) delete 1");
+//            System.out.println("- 종료: quit");
+//
+//            String input = scanner.nextLine();
+//            if (input.startsWith(ADD)) {
+//                String params = input.split(" ")[1];
+//
+//                String date = params.split(",")[0];
+//                String time = params.split(",")[1];
+//                String name = params.split(",")[2];
+//
+//                Reservation reservation = new Reservation(
+//                        null,
+//                        LocalDate.parse(date),
+//                        LocalTime.parse(time + ":00"),
+//                        name,
+//                        theme.getId()
+//                );
+//                Reservation createReservation = reservationService.registerReservation(reservation);
+//
+//                System.out.println("예약이 등록되었습니다.");
+//                System.out.println("예약 번호: " + createReservation.getId());
+//                System.out.println("예약 날짜: " + createReservation.getDate());
+//                System.out.println("예약 시간: " + createReservation.getTime());
+//                System.out.println("예약자 이름: " + createReservation.getName());
+//            }
+//
+//            if (input.startsWith(FIND)) {
+//                String params = input.split(" ")[1];
+//                long id = Long.parseLong(params.split(",")[0]);
+//                Reservation reservation = reservationService.findById(id);
+//
+//                System.out.println("예약 번호: " + reservation.getId());
+//                System.out.println("예약 날짜: " + reservation.getDate());
+//                System.out.println("예약 시간: " + reservation.getTime());
+//                System.out.println("예약자 이름: " + reservation.getName());
+//                System.out.println("예약 테마 ID: " + reservation.getThemeId());
+////                System.out.println("예약 테마 이름: " + reservation.getTheme().getName());
+////                System.out.println("예약 테마 설명: " + reservation.getTheme().getDesc());
+////                System.out.println("예약 테마 가격: " + reservation.getTheme().getPrice());
+//            }
+//
+//            if (input.startsWith(DELETE)) {
+//                String params = input.split(" ")[1];
+//
+//                long id = Long.parseLong(params.split(",")[0]);
+//
+//                if (reservationService.delete(id)) {
+//                    System.out.println("예약이 취소되었습니다.");
+//                }
+//            }
+//
+//            if (input.equals(QUIT)) {
+//                break;
+//            }
+//        }
+//    }
+//
+//    public static DataSource dataSource() {
+//        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+//        dataSource.setUsername("sa");
+//        dataSource.setPassword("");
+//        dataSource.setDriverClassName("org.h2.Driver");
+//        dataSource.setUrl("jdbc:h2:~/test");
+//        return dataSource;
+//    }
+//}

--- a/src/main/java/nextstep/reservation/constant/RoomEscapeConstant.java
+++ b/src/main/java/nextstep/reservation/constant/RoomEscapeConstant.java
@@ -2,4 +2,5 @@ package nextstep.reservation.constant;
 
 public class RoomEscapeConstant {
     public static final int ENTITY_DELETE_NUMBER = 1;
+    public static final long DUMMY_ID = 1L;
 }

--- a/src/main/java/nextstep/reservation/constant/RoomEscapeConstant.java
+++ b/src/main/java/nextstep/reservation/constant/RoomEscapeConstant.java
@@ -1,0 +1,5 @@
+package nextstep.reservation.constant;
+
+public class RoomEscapeConstant {
+    public static final int ENTITY_DELETE_NUMBER = 1;
+}

--- a/src/main/java/nextstep/reservation/constant/RoomEscapeConstant.java
+++ b/src/main/java/nextstep/reservation/constant/RoomEscapeConstant.java
@@ -2,5 +2,4 @@ package nextstep.reservation.constant;
 
 public class RoomEscapeConstant {
     public static final int ENTITY_DELETE_NUMBER = 1;
-    public static final long DUMMY_ID = 1L;
 }

--- a/src/main/java/nextstep/reservation/controller/ReservationController.java
+++ b/src/main/java/nextstep/reservation/controller/ReservationController.java
@@ -20,9 +20,8 @@ public class ReservationController {
 
     @PostMapping
     public ResponseEntity<Object> createReservation(@RequestBody Reservation reservation) {
-        Reservation createReservation;
-        createReservation = reservationService.create(reservation);
-        return ResponseEntity.created(URI.create("/reservations/" + createReservation.getId())).build();
+        Reservation registeredReservation = reservationService.registerReservation(reservation);
+        return ResponseEntity.created(URI.create("/reservations/" + registeredReservation.getId())).build();
     }
 
     @DeleteMapping

--- a/src/main/java/nextstep/reservation/controller/ReservationController.java
+++ b/src/main/java/nextstep/reservation/controller/ReservationController.java
@@ -1,7 +1,7 @@
 package nextstep.reservation.controller;
 
 import nextstep.reservation.entity.Reservation;
-import nextstep.reservation.exception.CreateReservationException;
+import nextstep.reservation.exception.ReservationException;
 import nextstep.reservation.service.ReservationService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -43,8 +43,8 @@ public class ReservationController {
         return ResponseEntity.noContent().build();
     }
 
-    @ExceptionHandler(CreateReservationException.class)
-    public ResponseEntity<String> handle(CreateReservationException exception) {
+    @ExceptionHandler(ReservationException.class)
+    public ResponseEntity<String> handle(ReservationException exception) {
         return ResponseEntity.badRequest().body(exception.getMessage());
     }
 }

--- a/src/main/java/nextstep/reservation/controller/ReservationController.java
+++ b/src/main/java/nextstep/reservation/controller/ReservationController.java
@@ -1,6 +1,8 @@
 package nextstep.reservation.controller;
 
-import nextstep.reservation.entity.Reservation;
+import lombok.RequiredArgsConstructor;
+import nextstep.reservation.dto.ReservationRequest;
+import nextstep.reservation.dto.ReservationResponse;
 import nextstep.reservation.exception.ReservationException;
 import nextstep.reservation.service.ReservationService;
 import org.springframework.http.ResponseEntity;
@@ -9,35 +11,33 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URI;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/reservations")
 public class ReservationController {
 
     private final ReservationService reservationService;
 
-    public ReservationController(ReservationService reservationService) {
-        this.reservationService = reservationService;
-    }
 
     @PostMapping
-    public ResponseEntity<Object> createReservation(@RequestBody Reservation reservation) {
-        Reservation registeredReservation = reservationService.registerReservation(reservation);
+    public ResponseEntity<Object> createReservation(@RequestBody ReservationRequest reservationRequest) {
+        ReservationResponse registeredReservation = reservationService.registerReservation(reservationRequest);
         return ResponseEntity.created(URI.create("/reservations/" + registeredReservation.getId())).build();
     }
 
     @DeleteMapping
-    public ResponseEntity<Reservation> clear() {
+    public ResponseEntity<ReservationResponse> clear() {
         reservationService.clear();
         return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Reservation> findReservation(@PathVariable Long id) {
-        Reservation reservation = reservationService.findById(id);
+    public ResponseEntity<ReservationResponse> findReservation(@PathVariable Long id) {
+        ReservationResponse reservation = reservationService.findById(id);
         return ResponseEntity.ok().body(reservation);
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Reservation> deleteReservation(@PathVariable Long id) {
+    public ResponseEntity<ReservationResponse> deleteReservation(@PathVariable Long id) {
         reservationService.delete(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/nextstep/reservation/controller/ReservationController.java
+++ b/src/main/java/nextstep/reservation/controller/ReservationController.java
@@ -3,7 +3,6 @@ package nextstep.reservation.controller;
 import nextstep.reservation.entity.Reservation;
 import nextstep.reservation.exception.CreateReservationException;
 import nextstep.reservation.service.ReservationService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -16,7 +15,6 @@ public class ReservationController {
 
     private final ReservationService reservationService;
 
-    @Autowired
     public ReservationController(ReservationService reservationService) {
         this.reservationService = reservationService;
     }

--- a/src/main/java/nextstep/reservation/controller/ReservationController.java
+++ b/src/main/java/nextstep/reservation/controller/ReservationController.java
@@ -18,14 +18,14 @@ public class ReservationController {
         this.reservationService = reservationService;
     }
 
-    @PostMapping("")
+    @PostMapping
     public ResponseEntity<Object> createReservation(@RequestBody Reservation reservation) {
         Reservation createReservation;
         createReservation = reservationService.create(reservation);
         return ResponseEntity.created(URI.create("/reservations/" + createReservation.getId())).build();
     }
 
-    @DeleteMapping("")
+    @DeleteMapping
     public ResponseEntity<Reservation> clear() {
         reservationService.clear();
         return ResponseEntity.noContent().build();

--- a/src/main/java/nextstep/reservation/controller/ReservationController.java
+++ b/src/main/java/nextstep/reservation/controller/ReservationController.java
@@ -3,7 +3,7 @@ package nextstep.reservation.controller;
 import lombok.RequiredArgsConstructor;
 import nextstep.reservation.dto.ReservationRequest;
 import nextstep.reservation.dto.ReservationResponse;
-import nextstep.reservation.exception.ReservationException;
+import nextstep.reservation.exception.RoomEscapeException;
 import nextstep.reservation.service.ReservationService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -42,8 +42,8 @@ public class ReservationController {
         return ResponseEntity.noContent().build();
     }
 
-    @ExceptionHandler(ReservationException.class)
-    public ResponseEntity<String> handle(ReservationException exception) {
+    @ExceptionHandler(RoomEscapeException.class)
+    public ResponseEntity<String> handle(RoomEscapeException exception) {
         return ResponseEntity.badRequest().body(exception.getMessage());
     }
 }

--- a/src/main/java/nextstep/reservation/controller/ReservationController.java
+++ b/src/main/java/nextstep/reservation/controller/ReservationController.java
@@ -4,12 +4,11 @@ import nextstep.reservation.entity.Reservation;
 import nextstep.reservation.exception.CreateReservationException;
 import nextstep.reservation.service.ReservationService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
-@Controller
+@RestController
 @RequestMapping("/reservations")
 public class ReservationController {
 

--- a/src/main/java/nextstep/reservation/controller/ThemeController.java
+++ b/src/main/java/nextstep/reservation/controller/ThemeController.java
@@ -1,5 +1,6 @@
 package nextstep.reservation.controller;
 
+import lombok.RequiredArgsConstructor;
 import nextstep.reservation.entity.Theme;
 import nextstep.reservation.service.ThemeService;
 import org.springframework.http.ResponseEntity;
@@ -9,18 +10,21 @@ import java.net.URI;
 import java.util.List;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/themes")
 public class ThemeController {
     private final ThemeService themeService;
-
-    public ThemeController(ThemeService themeService) {
-        this.themeService = themeService;
-    }
 
     @PostMapping
     ResponseEntity create(@RequestBody Theme theme) {
         Theme created = themeService.create(theme);
         return ResponseEntity.created(URI.create("/themes/" + created.getId())).build();
+    }
+
+    @GetMapping("/{id}")
+    ResponseEntity<Theme> findById(@PathVariable long id) {
+        Theme foundedTheme = themeService.findById(id);
+        return ResponseEntity.ok(foundedTheme);
     }
 
     @GetMapping

--- a/src/main/java/nextstep/reservation/controller/ThemeController.java
+++ b/src/main/java/nextstep/reservation/controller/ThemeController.java
@@ -1,7 +1,8 @@
 package nextstep.reservation.controller;
 
 import lombok.RequiredArgsConstructor;
-import nextstep.reservation.entity.Theme;
+import nextstep.reservation.dto.ThemeRequest;
+import nextstep.reservation.dto.ThemeResponse;
 import nextstep.reservation.service.ThemeService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,20 +17,20 @@ public class ThemeController {
     private final ThemeService themeService;
 
     @PostMapping
-    ResponseEntity create(@RequestBody Theme theme) {
-        Theme created = themeService.create(theme);
+    ResponseEntity create(@RequestBody ThemeRequest themeRequest) {
+        ThemeResponse created = themeService.registerTheme(themeRequest);
         return ResponseEntity.created(URI.create("/themes/" + created.getId())).build();
     }
 
     @GetMapping("/{id}")
-    ResponseEntity<Theme> findById(@PathVariable long id) {
-        Theme foundedTheme = themeService.findById(id);
+    ResponseEntity<ThemeResponse> findById(@PathVariable long id) {
+        ThemeResponse foundedTheme = themeService.findById(id);
         return ResponseEntity.ok(foundedTheme);
     }
 
     @GetMapping
-    ResponseEntity<List<Theme>> findAll() {
-        List<Theme> themeList = themeService.findAll();
+    ResponseEntity<List<ThemeResponse>> findAll() {
+        List<ThemeResponse> themeList = themeService.findAll();
         return ResponseEntity.ok().body(themeList);
     }
 

--- a/src/main/java/nextstep/reservation/controller/ThemeController.java
+++ b/src/main/java/nextstep/reservation/controller/ThemeController.java
@@ -1,0 +1,37 @@
+package nextstep.reservation.controller;
+
+import nextstep.reservation.entity.Theme;
+import nextstep.reservation.service.ThemeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/themes")
+public class ThemeController {
+    private final ThemeService themeService;
+
+    public ThemeController(ThemeService themeService) {
+        this.themeService = themeService;
+    }
+
+    @PostMapping
+    ResponseEntity create(@RequestBody Theme theme) {
+        Theme created = themeService.create(theme);
+        return ResponseEntity.created(URI.create("/themes/" + created.getId())).build();
+    }
+
+    @GetMapping
+    ResponseEntity<List<Theme>> findAll() {
+        List<Theme> themeList = themeService.findAll();
+        return ResponseEntity.ok().body(themeList);
+    }
+
+    @DeleteMapping("/{id}")
+    ResponseEntity deleteById(@PathVariable("id") long id) {
+        themeService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/nextstep/reservation/dto/ReservationRequest.java
+++ b/src/main/java/nextstep/reservation/dto/ReservationRequest.java
@@ -1,6 +1,7 @@
 package nextstep.reservation.dto;
 
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import nextstep.reservation.entity.Reservation;
@@ -10,6 +11,7 @@ import java.time.LocalTime;
 
 @Getter
 @RequiredArgsConstructor
+@Builder
 public class ReservationRequest {
     private final LocalDate date;
     private final LocalTime time;

--- a/src/main/java/nextstep/reservation/dto/ReservationRequest.java
+++ b/src/main/java/nextstep/reservation/dto/ReservationRequest.java
@@ -9,8 +9,6 @@ import nextstep.reservation.entity.Reservation;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-import static nextstep.reservation.constant.RoomEscapeConstant.DUMMY_ID;
-
 @Getter
 @RequiredArgsConstructor
 @Builder
@@ -23,7 +21,7 @@ public class ReservationRequest {
 
     public Reservation toEntityWithDummyId() {
         return Reservation.builder()
-                .id(DUMMY_ID)
+                .id(null)
                 .date(date)
                 .time(time)
                 .name(name)

--- a/src/main/java/nextstep/reservation/dto/ReservationRequest.java
+++ b/src/main/java/nextstep/reservation/dto/ReservationRequest.java
@@ -1,0 +1,28 @@
+package nextstep.reservation.dto;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import nextstep.reservation.entity.Reservation;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@RequiredArgsConstructor
+public class ReservationRequest {
+    private final LocalDate date;
+    private final LocalTime time;
+    private final String name;
+    private final Long themeId;
+
+
+    public Reservation toEntity() {
+        return Reservation.builder()
+                .date(date)
+                .time(time)
+                .name(name)
+                .themeId(themeId)
+                .build();
+    }
+}

--- a/src/main/java/nextstep/reservation/dto/ReservationRequest.java
+++ b/src/main/java/nextstep/reservation/dto/ReservationRequest.java
@@ -9,6 +9,8 @@ import nextstep.reservation.entity.Reservation;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+import static nextstep.reservation.constant.RoomEscapeConstant.DUMMY_ID;
+
 @Getter
 @RequiredArgsConstructor
 @Builder
@@ -19,8 +21,9 @@ public class ReservationRequest {
     private final Long themeId;
 
 
-    public Reservation toEntity() {
+    public Reservation toEntityWithDummyId() {
         return Reservation.builder()
+                .id(DUMMY_ID)
                 .date(date)
                 .time(time)
                 .name(name)

--- a/src/main/java/nextstep/reservation/dto/ReservationResponse.java
+++ b/src/main/java/nextstep/reservation/dto/ReservationResponse.java
@@ -1,5 +1,6 @@
 package nextstep.reservation.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import java.time.LocalTime;
 public class ReservationResponse {
     private final long id;
     private final LocalDate date;
+    @JsonFormat(shape= JsonFormat.Shape.STRING, pattern = "kk:mm")
     private final LocalTime time;
     private final String name;
     private final String themeName;

--- a/src/main/java/nextstep/reservation/dto/ReservationResponse.java
+++ b/src/main/java/nextstep/reservation/dto/ReservationResponse.java
@@ -16,6 +16,7 @@ public class ReservationResponse {
     private final LocalDate date;
     private final LocalTime time;
     private final String name;
+    private final long themeId;
     private final String themeName;
     private final String themeDesc;
     private final int themePrice;
@@ -26,6 +27,7 @@ public class ReservationResponse {
                 .date(reservation.getDate())
                 .time(reservation.getTime())
                 .name(reservation.getName())
+                .themeId(theme.getId())
                 .themeName(theme.getName())
                 .themeDesc(theme.getDesc())
                 .themePrice(theme.getPrice())

--- a/src/main/java/nextstep/reservation/dto/ReservationResponse.java
+++ b/src/main/java/nextstep/reservation/dto/ReservationResponse.java
@@ -1,0 +1,35 @@
+package nextstep.reservation.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import nextstep.reservation.entity.Reservation;
+import nextstep.reservation.entity.Theme;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@RequiredArgsConstructor
+@Builder
+@Getter
+public class ReservationResponse {
+    private final Long id;
+    private final LocalDate date;
+    private final LocalTime time;
+    private final String name;
+    private final String themeName;
+    private final String themeDesc;
+    private final int themePrice;
+
+    public static ReservationResponse from(Reservation reservation, Theme theme) {
+        return ReservationResponse.builder()
+                .id(reservation.getId())
+                .date(reservation.getDate())
+                .time(reservation.getTime())
+                .name(reservation.getName())
+                .themeName(theme.getName())
+                .themeDesc(theme.getDesc())
+                .themePrice(theme.getPrice())
+                .build();
+    }
+}

--- a/src/main/java/nextstep/reservation/dto/ReservationResponse.java
+++ b/src/main/java/nextstep/reservation/dto/ReservationResponse.java
@@ -18,19 +18,15 @@ public class ReservationResponse {
     @JsonFormat(shape= JsonFormat.Shape.STRING, pattern = "kk:mm")
     private final LocalTime time;
     private final String name;
-    private final String themeName;
-    private final String themeDesc;
-    private final int themePrice;
+    private final ThemeResponse themeResponse;
 
-    public static ReservationResponse from(Reservation reservation, ThemeResponse theme) {
+    public static ReservationResponse from(Reservation reservation, ThemeResponse themeResponse) {
         return ReservationResponse.builder()
                 .id(reservation.getId())
                 .date(reservation.getDate())
                 .time(reservation.getTime())
                 .name(reservation.getName())
-                .themeName(theme.getName())
-                .themeDesc(theme.getDesc())
-                .themePrice(theme.getPrice())
+                .themeResponse(themeResponse)
                 .build();
     }
 }

--- a/src/main/java/nextstep/reservation/dto/ReservationResponse.java
+++ b/src/main/java/nextstep/reservation/dto/ReservationResponse.java
@@ -4,7 +4,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import nextstep.reservation.entity.Reservation;
-import nextstep.reservation.entity.Theme;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -13,7 +12,7 @@ import java.time.LocalTime;
 @Builder
 @Getter
 public class ReservationResponse {
-    private final Long id;
+    private final long id;
     private final LocalDate date;
     private final LocalTime time;
     private final String name;
@@ -21,7 +20,7 @@ public class ReservationResponse {
     private final String themeDesc;
     private final int themePrice;
 
-    public static ReservationResponse from(Reservation reservation, Theme theme) {
+    public static ReservationResponse from(Reservation reservation, ThemeResponse theme) {
         return ReservationResponse.builder()
                 .id(reservation.getId())
                 .date(reservation.getDate())

--- a/src/main/java/nextstep/reservation/dto/ReservationResponse.java
+++ b/src/main/java/nextstep/reservation/dto/ReservationResponse.java
@@ -1,10 +1,13 @@
 package nextstep.reservation.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import nextstep.reservation.entity.Reservation;
+import nextstep.reservation.serializer.ThemeResponseSerializer;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -15,9 +18,11 @@ import java.time.LocalTime;
 public class ReservationResponse {
     private final long id;
     private final LocalDate date;
-    @JsonFormat(shape= JsonFormat.Shape.STRING, pattern = "kk:mm")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "kk:mm")
     private final LocalTime time;
     private final String name;
+    @JsonSerialize(using = ThemeResponseSerializer.class)
+    @JsonUnwrapped
     private final ThemeResponse themeResponse;
 
     public static ReservationResponse from(Reservation reservation, ThemeResponse themeResponse) {

--- a/src/main/java/nextstep/reservation/dto/ReservationResponse.java
+++ b/src/main/java/nextstep/reservation/dto/ReservationResponse.java
@@ -16,7 +16,6 @@ public class ReservationResponse {
     private final LocalDate date;
     private final LocalTime time;
     private final String name;
-    private final long themeId;
     private final String themeName;
     private final String themeDesc;
     private final int themePrice;
@@ -27,7 +26,6 @@ public class ReservationResponse {
                 .date(reservation.getDate())
                 .time(reservation.getTime())
                 .name(reservation.getName())
-                .themeId(theme.getId())
                 .themeName(theme.getName())
                 .themeDesc(theme.getDesc())
                 .themePrice(theme.getPrice())

--- a/src/main/java/nextstep/reservation/dto/ThemeRequest.java
+++ b/src/main/java/nextstep/reservation/dto/ThemeRequest.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import nextstep.reservation.entity.Theme;
 
+import static nextstep.reservation.constant.RoomEscapeConstant.DUMMY_ID;
+
 @RequiredArgsConstructor
 @Getter
 @Builder
@@ -13,8 +15,9 @@ public class ThemeRequest {
     private final String desc;
     private final Integer price;
 
-    public Theme toEntity() {
+    public Theme toEntityWithDummyId() {
         return Theme.builder()
+                .id(DUMMY_ID)
                 .name(name)
                 .desc(desc)
                 .price(price)

--- a/src/main/java/nextstep/reservation/dto/ThemeRequest.java
+++ b/src/main/java/nextstep/reservation/dto/ThemeRequest.java
@@ -1,0 +1,23 @@
+package nextstep.reservation.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import nextstep.reservation.entity.Theme;
+
+@RequiredArgsConstructor
+@Getter
+@Builder
+public class ThemeRequest {
+    private final String name;
+    private final String desc;
+    private final Integer price;
+
+    public Theme toEntity() {
+        return Theme.builder()
+                .name(name)
+                .desc(desc)
+                .price(price)
+                .build();
+    }
+}

--- a/src/main/java/nextstep/reservation/dto/ThemeRequest.java
+++ b/src/main/java/nextstep/reservation/dto/ThemeRequest.java
@@ -5,8 +5,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import nextstep.reservation.entity.Theme;
 
-import static nextstep.reservation.constant.RoomEscapeConstant.DUMMY_ID;
-
 @RequiredArgsConstructor
 @Getter
 @Builder
@@ -17,7 +15,7 @@ public class ThemeRequest {
 
     public Theme toEntityWithDummyId() {
         return Theme.builder()
-                .id(DUMMY_ID)
+                .id(null)
                 .name(name)
                 .desc(desc)
                 .price(price)

--- a/src/main/java/nextstep/reservation/dto/ThemeResponse.java
+++ b/src/main/java/nextstep/reservation/dto/ThemeResponse.java
@@ -1,0 +1,25 @@
+package nextstep.reservation.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import nextstep.reservation.entity.Theme;
+
+@RequiredArgsConstructor
+@Getter
+@Builder
+public class ThemeResponse {
+    private final long id;
+    private final String name;
+    private final String desc;
+    private final Integer price;
+
+    public static ThemeResponse from(Theme theme) {
+        return ThemeResponse.builder()
+                .id(theme.getId())
+                .name(theme.getName())
+                .desc(theme.getDesc())
+                .price(theme.getPrice())
+                .build();
+    }
+}

--- a/src/main/java/nextstep/reservation/entity/Reservation.java
+++ b/src/main/java/nextstep/reservation/entity/Reservation.java
@@ -12,14 +12,14 @@ public class Reservation {
     private final LocalDate date;
     private final LocalTime time;
     private final String name;
-    private final Theme theme;
+    private final Long themeId;
 
-    public Reservation(Long id, LocalDate date, LocalTime time, String name, Theme theme) {
+    public Reservation(Long id, LocalDate date, LocalTime time, String name, long theme) {
         this.id = id;
         this.date = date;
         this.time = time;
         this.name = name;
-        this.theme = theme;
+        this.themeId = theme;
     }
 
     public Long getId() {
@@ -38,8 +38,8 @@ public class Reservation {
         return name;
     }
 
-    public Theme getTheme() {
-        return theme;
+    public Long getThemeId() {
+        return themeId;
     }
 
     @Override
@@ -47,11 +47,11 @@ public class Reservation {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Reservation that = (Reservation) o;
-        return Objects.equals(date, that.date) && Objects.equals(time, that.time) && Objects.equals(name, that.name) && Objects.equals(theme, that.theme);
+        return Objects.equals(date, that.date) && Objects.equals(time, that.time) && Objects.equals(name, that.name) && Objects.equals(themeId, that.themeId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, date, time, name, theme);
+        return Objects.hash(id, date, time, name, themeId);
     }
 }

--- a/src/main/java/nextstep/reservation/entity/Reservation.java
+++ b/src/main/java/nextstep/reservation/entity/Reservation.java
@@ -1,11 +1,18 @@
 package nextstep.reservation.entity;
 
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.lang.Nullable;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.Objects;
 
+@RequiredArgsConstructor
+@Getter
+@EqualsAndHashCode
+@Builder
 public class Reservation {
     @Nullable
     private final Long id;
@@ -14,44 +21,4 @@ public class Reservation {
     private final String name;
     private final Long themeId;
 
-    public Reservation(Long id, LocalDate date, LocalTime time, String name, long theme) {
-        this.id = id;
-        this.date = date;
-        this.time = time;
-        this.name = name;
-        this.themeId = theme;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public LocalDate getDate() {
-        return date;
-    }
-
-    public LocalTime getTime() {
-        return time;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public Long getThemeId() {
-        return themeId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Reservation that = (Reservation) o;
-        return Objects.equals(date, that.date) && Objects.equals(time, that.time) && Objects.equals(name, that.name) && Objects.equals(themeId, that.themeId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, date, time, name, themeId);
-    }
 }

--- a/src/main/java/nextstep/reservation/entity/Reservation.java
+++ b/src/main/java/nextstep/reservation/entity/Reservation.java
@@ -1,9 +1,6 @@
 package nextstep.reservation.entity;
 
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import org.springframework.lang.Nullable;
 
 import java.time.LocalDate;
@@ -14,11 +11,15 @@ import java.time.LocalTime;
 @EqualsAndHashCode
 @Builder
 public class Reservation {
-    @Nullable
+    @NonNull
     private final Long id;
+    @Nullable
     private final LocalDate date;
+    @Nullable
     private final LocalTime time;
+    @Nullable
     private final String name;
+    @NonNull
     private final Long themeId;
 
 }

--- a/src/main/java/nextstep/reservation/entity/Reservation.java
+++ b/src/main/java/nextstep/reservation/entity/Reservation.java
@@ -11,13 +11,13 @@ import java.time.LocalTime;
 @EqualsAndHashCode
 @Builder
 public class Reservation {
-    @NonNull
+    @Nullable
     private final Long id;
-    @Nullable
+    @NonNull
     private final LocalDate date;
-    @Nullable
+    @NonNull
     private final LocalTime time;
-    @Nullable
+    @NonNull
     private final String name;
     @NonNull
     private final Long themeId;

--- a/src/main/java/nextstep/reservation/entity/Theme.java
+++ b/src/main/java/nextstep/reservation/entity/Theme.java
@@ -1,16 +1,26 @@
 package nextstep.reservation.entity;
 
+import org.springframework.lang.Nullable;
+
 import java.util.Objects;
 
 public class Theme {
+    @Nullable
+    private final Long id;
     private final String name;
     private final String desc;
     private final Integer price;
 
-    public Theme(String name, String desc, Integer price) {
+    public Theme(Long id, String name, String desc, Integer price) {
+        this.id = id;
         this.name = name;
         this.desc = desc;
         this.price = price;
+    }
+
+    @Nullable
+    public Long getId() {
+        return id;
     }
 
     public String getName() {

--- a/src/main/java/nextstep/reservation/entity/Theme.java
+++ b/src/main/java/nextstep/reservation/entity/Theme.java
@@ -9,12 +9,12 @@ import org.springframework.lang.Nullable;
 @EqualsAndHashCode
 @Builder
 public class Theme {
-    @NonNull
+    @Nullable
     private final Long id;
-    @Nullable
+    @NonNull
     private final String name;
-    @Nullable
+    @NonNull
     private final String desc;
-    @Nullable
+    @NonNull
     private final Integer price;
 }

--- a/src/main/java/nextstep/reservation/entity/Theme.java
+++ b/src/main/java/nextstep/reservation/entity/Theme.java
@@ -1,50 +1,20 @@
 package nextstep.reservation.entity;
 
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.lang.Nullable;
 
-import java.util.Objects;
 
+@RequiredArgsConstructor
+@Getter
+@EqualsAndHashCode
+@Builder
 public class Theme {
     @Nullable
     private final Long id;
     private final String name;
     private final String desc;
     private final Integer price;
-
-    public Theme(Long id, String name, String desc, Integer price) {
-        this.id = id;
-        this.name = name;
-        this.desc = desc;
-        this.price = price;
-    }
-
-    @Nullable
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getDesc() {
-        return desc;
-    }
-
-    public Integer getPrice() {
-        return price;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Theme theme = (Theme) o;
-        return Objects.equals(name, theme.name) && Objects.equals(desc, theme.desc) && Objects.equals(price, theme.price);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(name, desc, price);
-    }
 }

--- a/src/main/java/nextstep/reservation/entity/Theme.java
+++ b/src/main/java/nextstep/reservation/entity/Theme.java
@@ -1,9 +1,6 @@
 package nextstep.reservation.entity;
 
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import org.springframework.lang.Nullable;
 
 
@@ -12,9 +9,12 @@ import org.springframework.lang.Nullable;
 @EqualsAndHashCode
 @Builder
 public class Theme {
-    @Nullable
+    @NonNull
     private final Long id;
+    @Nullable
     private final String name;
+    @Nullable
     private final String desc;
+    @Nullable
     private final Integer price;
 }

--- a/src/main/java/nextstep/reservation/exception/CreateReservationException.java
+++ b/src/main/java/nextstep/reservation/exception/CreateReservationException.java
@@ -1,7 +1,0 @@
-package nextstep.reservation.exception;
-
-public class CreateReservationException extends RuntimeException {
-    public CreateReservationException(ReservationExceptionCode code) {
-        super(code.getMessage());
-    }
-}

--- a/src/main/java/nextstep/reservation/exception/ReservationException.java
+++ b/src/main/java/nextstep/reservation/exception/ReservationException.java
@@ -1,7 +1,0 @@
-package nextstep.reservation.exception;
-
-public class ReservationException extends RuntimeException {
-    public ReservationException(ReservationExceptionCode code) {
-        super(code.getMessage());
-    }
-}

--- a/src/main/java/nextstep/reservation/exception/ReservationException.java
+++ b/src/main/java/nextstep/reservation/exception/ReservationException.java
@@ -1,0 +1,7 @@
+package nextstep.reservation.exception;
+
+public class ReservationException extends RuntimeException {
+    public ReservationException(ReservationExceptionCode code) {
+        super(code.getMessage());
+    }
+}

--- a/src/main/java/nextstep/reservation/exception/ReservationExceptionCode.java
+++ b/src/main/java/nextstep/reservation/exception/ReservationExceptionCode.java
@@ -1,7 +1,8 @@
 package nextstep.reservation.exception;
 
 public enum ReservationExceptionCode {
-    DUPLICATE_TIME_RESERVATION("해당 시간에 예약이 이미 존재합니다.");
+    DUPLICATE_TIME_RESERVATION("해당 시간에 예약이 이미 존재합니다."),
+    NO_SUCH_RESERVATION("예약이 존재하지 않습니다.");
 
     private final String message;
 

--- a/src/main/java/nextstep/reservation/exception/ReservationExceptionCode.java
+++ b/src/main/java/nextstep/reservation/exception/ReservationExceptionCode.java
@@ -2,7 +2,8 @@ package nextstep.reservation.exception;
 
 public enum ReservationExceptionCode {
     DUPLICATE_TIME_RESERVATION("해당 시간에 예약이 이미 존재합니다."),
-    NO_SUCH_RESERVATION("예약이 존재하지 않습니다.");
+    NO_SUCH_RESERVATION("예약이 존재하지 않습니다."),
+    NO_SUCH_THEME("해당 테마가 존재하지 않습니다.");
 
     private final String message;
 

--- a/src/main/java/nextstep/reservation/exception/RoomEscapeException.java
+++ b/src/main/java/nextstep/reservation/exception/RoomEscapeException.java
@@ -1,0 +1,7 @@
+package nextstep.reservation.exception;
+
+public class RoomEscapeException extends RuntimeException {
+    public RoomEscapeException(RoomEscapeExceptionCode code) {
+        super(code.getMessage());
+    }
+}

--- a/src/main/java/nextstep/reservation/exception/RoomEscapeExceptionCode.java
+++ b/src/main/java/nextstep/reservation/exception/RoomEscapeExceptionCode.java
@@ -3,7 +3,8 @@ package nextstep.reservation.exception;
 public enum RoomEscapeExceptionCode {
     DUPLICATE_TIME_RESERVATION("해당 시간에 예약이 이미 존재합니다."),
     NO_SUCH_RESERVATION("예약이 존재하지 않습니다."),
-    NO_SUCH_THEME("해당 테마가 존재하지 않습니다.");
+    NO_SUCH_THEME("해당 테마가 존재하지 않습니다."),
+    RESERVATION_EXIST("해당 테마로 예약이 존재합니다.");
 
     private final String message;
 

--- a/src/main/java/nextstep/reservation/exception/RoomEscapeExceptionCode.java
+++ b/src/main/java/nextstep/reservation/exception/RoomEscapeExceptionCode.java
@@ -1,13 +1,13 @@
 package nextstep.reservation.exception;
 
-public enum ReservationExceptionCode {
+public enum RoomEscapeExceptionCode {
     DUPLICATE_TIME_RESERVATION("해당 시간에 예약이 이미 존재합니다."),
     NO_SUCH_RESERVATION("예약이 존재하지 않습니다."),
     NO_SUCH_THEME("해당 테마가 존재하지 않습니다.");
 
     private final String message;
 
-    ReservationExceptionCode(String message) {
+    RoomEscapeExceptionCode(String message) {
         this.message = message;
     }
 

--- a/src/main/java/nextstep/reservation/repository/JdbcReservationRepository.java
+++ b/src/main/java/nextstep/reservation/repository/JdbcReservationRepository.java
@@ -31,8 +31,8 @@ public class JdbcReservationRepository implements ReservationRepository {
     }
 
     @Override
-    public Reservation create(Reservation reservation) {
-        if (findByDateTime(reservation.getDate(), reservation.getTime())) {
+    public Reservation save(Reservation reservation) {
+        if (findByDateAndTime(reservation.getDate(), reservation.getTime())) {
             throw new ReservationException(DUPLICATE_TIME_RESERVATION);
         }
 
@@ -69,13 +69,13 @@ public class JdbcReservationRepository implements ReservationRepository {
     }
 
     @Override
-    public Boolean findByDateTime(LocalDate date, LocalTime time) {
+    public Boolean findByDateAndTime(LocalDate date, LocalTime time) {
         String sql = "select exists (select * from reservation where date= ? and time = ?)";
         return jdbcTemplate.queryForObject(sql, Boolean.class, date, time);
     }
 
     @Override
-    public Boolean delete(long id) {
+    public Boolean deleteById(long id) {
         String sql = "delete from reservation where id = ?";
         return jdbcTemplate.update(sql, id) == 1;
     }

--- a/src/main/java/nextstep/reservation/repository/JdbcReservationRepository.java
+++ b/src/main/java/nextstep/reservation/repository/JdbcReservationRepository.java
@@ -47,7 +47,13 @@ public class JdbcReservationRepository implements ReservationRepository {
             return ps;
         }, keyHolder);
 
-        return new Reservation(keyHolder.getKey().longValue(), reservation.getDate(), reservation.getTime(), reservation.getName(), reservation.getThemeId());
+        return Reservation.builder()
+                .id(keyHolder.getKey().longValue())
+                .date(reservation.getDate())
+                .time(reservation.getTime())
+                .name(reservation.getName())
+                .themeId(reservation.getThemeId())
+                .build();
     }
 
     @Override
@@ -81,12 +87,13 @@ public class JdbcReservationRepository implements ReservationRepository {
     }
 
     public RowMapper<Reservation> reservationRowMapper() {
-        return (resultSet, rowNum) -> new Reservation(
-                resultSet.getLong("id"),
-                resultSet.getDate("date").toLocalDate(),
-                resultSet.getTime("time").toLocalTime(),
-                resultSet.getString("name"),
-                resultSet.getLong("theme_id"));
+        return (resultSet, rowNum) -> Reservation.builder()
+                .id(resultSet.getLong("id"))
+                .date(resultSet.getDate("date").toLocalDate())
+                .time(resultSet.getTime("time").toLocalTime())
+                .name(resultSet.getString("name"))
+                .themeId(resultSet.getLong("theme_id"))
+                .build();
     }
 
 }

--- a/src/main/java/nextstep/reservation/repository/JdbcReservationRepository.java
+++ b/src/main/java/nextstep/reservation/repository/JdbcReservationRepository.java
@@ -1,7 +1,7 @@
 package nextstep.reservation.repository;
 
+import lombok.RequiredArgsConstructor;
 import nextstep.reservation.entity.Reservation;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -19,13 +19,9 @@ import java.util.Optional;
 
 @Repository
 @Primary
+@RequiredArgsConstructor
 public class JdbcReservationRepository implements ReservationRepository {
     private final JdbcTemplate jdbcTemplate;
-
-    @Autowired
-    public JdbcReservationRepository(JdbcTemplate jdbcTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     public Reservation save(Reservation reservation) {

--- a/src/main/java/nextstep/reservation/repository/JdbcReservationRepository.java
+++ b/src/main/java/nextstep/reservation/repository/JdbcReservationRepository.java
@@ -32,7 +32,7 @@ public class JdbcReservationRepository implements ReservationRepository {
 
     @Override
     public Reservation save(Reservation reservation) {
-        if (findByDateAndTime(reservation.getDate(), reservation.getTime())) {
+        if (findByDateAndTime(reservation.getDate(), reservation.getTime()).size() > 0) {
             throw new ReservationException(DUPLICATE_TIME_RESERVATION);
         }
 
@@ -69,15 +69,15 @@ public class JdbcReservationRepository implements ReservationRepository {
     }
 
     @Override
-    public Boolean findByDateAndTime(LocalDate date, LocalTime time) {
-        String sql = "select exists (select * from reservation where date= ? and time = ?)";
-        return jdbcTemplate.queryForObject(sql, Boolean.class, date, time);
+    public List<Reservation> findByDateAndTime(LocalDate date, LocalTime time) {
+        String sql = "select * from reservation where date= ? and time = ?";
+        return jdbcTemplate.query(sql, reservationRowMapper(), date, time);
     }
 
     @Override
-    public Boolean deleteById(long id) {
+    public int deleteById(long id) {
         String sql = "delete from reservation where id = ?";
-        return jdbcTemplate.update(sql, id) == 1;
+        return jdbcTemplate.update(sql, id);
     }
 
     @Override

--- a/src/main/java/nextstep/reservation/repository/JdbcReservationRepository.java
+++ b/src/main/java/nextstep/reservation/repository/JdbcReservationRepository.java
@@ -1,8 +1,6 @@
 package nextstep.reservation.repository;
 
 import nextstep.reservation.entity.Reservation;
-import nextstep.reservation.exception.ReservationException;
-import nextstep.reservation.exception.ReservationExceptionCode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -17,8 +15,7 @@ import java.sql.Time;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
-
-import static nextstep.reservation.exception.ReservationExceptionCode.DUPLICATE_TIME_RESERVATION;
+import java.util.Optional;
 
 @Repository
 @Primary
@@ -32,10 +29,6 @@ public class JdbcReservationRepository implements ReservationRepository {
 
     @Override
     public Reservation save(Reservation reservation) {
-        if (findByDateAndTime(reservation.getDate(), reservation.getTime()).size() > 0) {
-            throw new ReservationException(DUPLICATE_TIME_RESERVATION);
-        }
-
         String sql = "insert into reservation (date, time, name, theme_id) values(?,?,?,?)";
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(connection -> {
@@ -57,15 +50,10 @@ public class JdbcReservationRepository implements ReservationRepository {
     }
 
     @Override
-    public Reservation findById(long id) {
+    public Optional<Reservation> findById(long id) {
         String sql = "select * from reservation where id= ?";
         List<Reservation> reservationList = jdbcTemplate.query(sql, reservationRowMapper(), id);
-
-        Reservation reservation = reservationList.stream().findAny().orElse(null);
-        if (reservation == null) {
-            throw new ReservationException(ReservationExceptionCode.NO_SUCH_RESERVATION);
-        }
-        return reservationList.stream().findAny().orElse(null);
+        return reservationList.stream().findAny();
     }
 
     @Override

--- a/src/main/java/nextstep/reservation/repository/JdbcThemeRepository.java
+++ b/src/main/java/nextstep/reservation/repository/JdbcThemeRepository.java
@@ -1,0 +1,66 @@
+package nextstep.reservation.repository;
+
+import nextstep.reservation.entity.Theme;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+
+@Repository
+public class JdbcThemeRepository implements ThemeRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    public JdbcThemeRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public Theme create(Theme theme) {
+        String sql = "insert into THEME (name, desc, price) values (?, ?, ?)";
+        KeyHolder themeKeyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update((con -> {
+            PreparedStatement psmt = con.prepareStatement(sql, new String[]{"id"});
+            psmt.setString(1, theme.getName());
+            psmt.setString(2, theme.getDesc());
+            psmt.setInt(3, theme.getPrice());
+
+            return psmt;
+        }), themeKeyHolder);
+
+        return new Theme(themeKeyHolder.getKey().longValue(),
+                theme.getName(),
+                theme.getDesc(),
+                theme.getPrice());
+    }
+
+    @Override
+    public List<Theme> findAll() {
+        String sql = "select * from THEME";
+        List<Theme> themeList = jdbcTemplate.query(sql, themeRowMapper());
+        return themeList;
+    }
+
+    @Override
+    public int deleteById(Long id) {
+        String sql = "delete from THEME where id = ?";
+        return jdbcTemplate.update(sql, id);
+    }
+
+    @Override
+    public void clear() {
+        String sql = "delete from THEME";
+        jdbcTemplate.update(sql);
+    }
+
+    private RowMapper<Theme> themeRowMapper() {
+        return (rs, rowNum) -> new Theme(
+                rs.getLong("id"),
+                rs.getString("name"),
+                rs.getString("desc"),
+                rs.getInt("price"));
+    }
+}

--- a/src/main/java/nextstep/reservation/repository/JdbcThemeRepository.java
+++ b/src/main/java/nextstep/reservation/repository/JdbcThemeRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 
 import java.sql.PreparedStatement;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -38,6 +39,13 @@ public class JdbcThemeRepository implements ThemeRepository {
     }
 
     @Override
+    public Optional<Theme> findById(long id) {
+        String sql = "select * from THEME where id = ?";
+        List<Theme> theme = jdbcTemplate.query(sql, themeRowMapper(), id);
+        return theme.stream().findAny();
+    }
+
+    @Override
     public List<Theme> findAll() {
         String sql = "select * from THEME";
         List<Theme> themeList = jdbcTemplate.query(sql, themeRowMapper());
@@ -45,7 +53,7 @@ public class JdbcThemeRepository implements ThemeRepository {
     }
 
     @Override
-    public int deleteById(Long id) {
+    public int deleteById(long id) {
         String sql = "delete from THEME where id = ?";
         return jdbcTemplate.update(sql, id);
     }

--- a/src/main/java/nextstep/reservation/repository/JdbcThemeRepository.java
+++ b/src/main/java/nextstep/reservation/repository/JdbcThemeRepository.java
@@ -32,6 +32,7 @@ public class JdbcThemeRepository implements ThemeRepository {
         }), themeKeyHolder);
 
         return Theme.builder()
+                .id(themeKeyHolder.getKey().longValue())
                 .name(theme.getName())
                 .desc(theme.getDesc())
                 .price(theme.getPrice())

--- a/src/main/java/nextstep/reservation/repository/JdbcThemeRepository.java
+++ b/src/main/java/nextstep/reservation/repository/JdbcThemeRepository.java
@@ -1,5 +1,6 @@
 package nextstep.reservation.repository;
 
+import lombok.RequiredArgsConstructor;
 import nextstep.reservation.entity.Theme;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -11,12 +12,9 @@ import java.sql.PreparedStatement;
 import java.util.List;
 
 @Repository
+@RequiredArgsConstructor
 public class JdbcThemeRepository implements ThemeRepository {
     private final JdbcTemplate jdbcTemplate;
-
-    public JdbcThemeRepository(JdbcTemplate jdbcTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     public Theme save(Theme theme) {

--- a/src/main/java/nextstep/reservation/repository/JdbcThemeRepository.java
+++ b/src/main/java/nextstep/reservation/repository/JdbcThemeRepository.java
@@ -19,7 +19,7 @@ public class JdbcThemeRepository implements ThemeRepository {
     }
 
     @Override
-    public Theme create(Theme theme) {
+    public Theme save(Theme theme) {
         String sql = "insert into THEME (name, desc, price) values (?, ?, ?)";
         KeyHolder themeKeyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update((con -> {

--- a/src/main/java/nextstep/reservation/repository/JdbcThemeRepository.java
+++ b/src/main/java/nextstep/reservation/repository/JdbcThemeRepository.java
@@ -56,7 +56,7 @@ public class JdbcThemeRepository implements ThemeRepository {
 
     @Override
     public int deleteById(long id) {
-        String existsQuery = "select exists(select * from RESERVATION where theme_id = id)";
+        String existsQuery = "select exists(select * from RESERVATION where theme_id = ?)";
         Boolean isExistInReservation = jdbcTemplate.queryForObject(existsQuery, Boolean.class, id);
         if (isExistInReservation) {
             throw new RoomEscapeException(RoomEscapeExceptionCode.RESERVATION_EXIST);

--- a/src/main/java/nextstep/reservation/repository/JdbcThemeRepository.java
+++ b/src/main/java/nextstep/reservation/repository/JdbcThemeRepository.java
@@ -31,10 +31,11 @@ public class JdbcThemeRepository implements ThemeRepository {
             return psmt;
         }), themeKeyHolder);
 
-        return new Theme(themeKeyHolder.getKey().longValue(),
-                theme.getName(),
-                theme.getDesc(),
-                theme.getPrice());
+        return Theme.builder()
+                .name(theme.getName())
+                .desc(theme.getDesc())
+                .price(theme.getPrice())
+                .build();
     }
 
     @Override
@@ -57,10 +58,11 @@ public class JdbcThemeRepository implements ThemeRepository {
     }
 
     private RowMapper<Theme> themeRowMapper() {
-        return (rs, rowNum) -> new Theme(
-                rs.getLong("id"),
-                rs.getString("name"),
-                rs.getString("desc"),
-                rs.getInt("price"));
+        return (rs, rowNum) -> Theme.builder()
+                .id(rs.getLong("id"))
+                .name(rs.getString("name"))
+                .desc(rs.getString("desc"))
+                .price(rs.getInt("price"))
+                .build();
     }
 }

--- a/src/main/java/nextstep/reservation/repository/JdbcThemeRepository.java
+++ b/src/main/java/nextstep/reservation/repository/JdbcThemeRepository.java
@@ -2,6 +2,8 @@ package nextstep.reservation.repository;
 
 import lombok.RequiredArgsConstructor;
 import nextstep.reservation.entity.Theme;
+import nextstep.reservation.exception.RoomEscapeException;
+import nextstep.reservation.exception.RoomEscapeExceptionCode;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -54,6 +56,11 @@ public class JdbcThemeRepository implements ThemeRepository {
 
     @Override
     public int deleteById(long id) {
+        String existsQuery = "select exists(select * from RESERVATION where theme_id = id)";
+        Boolean isExistInReservation = jdbcTemplate.queryForObject(existsQuery, Boolean.class, id);
+        if (isExistInReservation) {
+            throw new RoomEscapeException(RoomEscapeExceptionCode.RESERVATION_EXIST);
+        }
         String sql = "delete from THEME where id = ?";
         return jdbcTemplate.update(sql, id);
     }

--- a/src/main/java/nextstep/reservation/repository/MemoryReservationRepository.java
+++ b/src/main/java/nextstep/reservation/repository/MemoryReservationRepository.java
@@ -8,6 +8,7 @@ import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -30,8 +31,8 @@ public class MemoryReservationRepository implements ReservationRepository {
     }
 
     @Override
-    public Reservation findById(long id) {
-        return reservationList.getOrDefault(id, null);
+    public Optional<Reservation> findById(long id) {
+        return Optional.ofNullable(reservationList.getOrDefault(id, null));
     }
 
     @Override

--- a/src/main/java/nextstep/reservation/repository/MemoryReservationRepository.java
+++ b/src/main/java/nextstep/reservation/repository/MemoryReservationRepository.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
+import static nextstep.reservation.constant.RoomEscapeConstant.ENTITY_DELETE_NUMBER;
 import static nextstep.reservation.exception.RoomEscapeExceptionCode.DUPLICATE_TIME_RESERVATION;
 
 
@@ -48,7 +49,7 @@ public class MemoryReservationRepository implements ReservationRepository {
     public int deleteById(long id) {
         if (reservationList.containsKey(id)) {
             reservationList.remove(id);
-            return 1;
+            return ENTITY_DELETE_NUMBER;
         }
         return 0;
     }

--- a/src/main/java/nextstep/reservation/repository/MemoryReservationRepository.java
+++ b/src/main/java/nextstep/reservation/repository/MemoryReservationRepository.java
@@ -22,7 +22,7 @@ public class MemoryReservationRepository implements ReservationRepository {
             throw new ReservationException(DUPLICATE_TIME_RESERVATION);
         }
         Long id = reservationCount.getAndIncrement();
-        Reservation creatteReservation = new Reservation(id, reservation.getDate(), reservation.getTime(), reservation.getName(), reservation.getTheme());
+        Reservation creatteReservation = new Reservation(id, reservation.getDate(), reservation.getTime(), reservation.getName(), reservation.getThemeId());
         reservationList.put(id, creatteReservation);
         return creatteReservation;
     }

--- a/src/main/java/nextstep/reservation/repository/MemoryReservationRepository.java
+++ b/src/main/java/nextstep/reservation/repository/MemoryReservationRepository.java
@@ -6,8 +6,10 @@ import nextstep.reservation.exception.ReservationException;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static nextstep.reservation.exception.ReservationExceptionCode.DUPLICATE_TIME_RESERVATION;
 
@@ -18,7 +20,7 @@ public class MemoryReservationRepository implements ReservationRepository {
 
     @Override
     public Reservation save(Reservation reservation) {
-        if (findByDateAndTime(reservation.getDate(), reservation.getTime())) {
+        if (findByDateAndTime(reservation.getDate(), reservation.getTime()).size() > 0) {
             throw new ReservationException(DUPLICATE_TIME_RESERVATION);
         }
         Long id = reservationCount.getAndIncrement();
@@ -31,21 +33,23 @@ public class MemoryReservationRepository implements ReservationRepository {
     public Reservation findById(long id) {
         return reservationList.getOrDefault(id, null);
     }
+
     @Override
-    public Boolean findByDateAndTime(LocalDate date, LocalTime time) {
+    public List<Reservation> findByDateAndTime(LocalDate date, LocalTime time) {
         return reservationList
                 .values()
                 .stream()
-                .anyMatch(reservation -> reservation.getDate().equals(date) && reservation.getTime().equals(time));
+                .filter(reservation -> reservation.getDate().equals(date) && reservation.getTime().equals(time))
+                .collect(Collectors.toList());
     }
 
     @Override
-    public Boolean deleteById(long id) {
+    public int deleteById(long id) {
         if (reservationList.containsKey(id)) {
             reservationList.remove(id);
-            return true;
+            return 1;
         }
-        return false;
+        return 0;
     }
 
     @Override

--- a/src/main/java/nextstep/reservation/repository/MemoryReservationRepository.java
+++ b/src/main/java/nextstep/reservation/repository/MemoryReservationRepository.java
@@ -1,7 +1,7 @@
 package nextstep.reservation.repository;
 
 import nextstep.reservation.entity.Reservation;
-import nextstep.reservation.exception.CreateReservationException;
+import nextstep.reservation.exception.ReservationException;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -19,7 +19,7 @@ public class MemoryReservationRepository implements ReservationRepository {
     @Override
     public Reservation create(Reservation reservation) {
         if (findByDateTime(reservation.getDate(), reservation.getTime())) {
-            throw new CreateReservationException(DUPLICATE_TIME_RESERVATION);
+            throw new ReservationException(DUPLICATE_TIME_RESERVATION);
         }
         Long id = reservationCount.getAndIncrement();
         Reservation creatteReservation = new Reservation(id, reservation.getDate(), reservation.getTime(), reservation.getName(), reservation.getTheme());

--- a/src/main/java/nextstep/reservation/repository/MemoryReservationRepository.java
+++ b/src/main/java/nextstep/reservation/repository/MemoryReservationRepository.java
@@ -1,7 +1,7 @@
 package nextstep.reservation.repository;
 
 import nextstep.reservation.entity.Reservation;
-import nextstep.reservation.exception.ReservationException;
+import nextstep.reservation.exception.RoomEscapeException;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -12,7 +12,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
-import static nextstep.reservation.exception.ReservationExceptionCode.DUPLICATE_TIME_RESERVATION;
+import static nextstep.reservation.exception.RoomEscapeExceptionCode.DUPLICATE_TIME_RESERVATION;
 
 
 public class MemoryReservationRepository implements ReservationRepository {
@@ -22,7 +22,7 @@ public class MemoryReservationRepository implements ReservationRepository {
     @Override
     public Reservation save(Reservation reservation) {
         if (findByDateAndTime(reservation.getDate(), reservation.getTime()).size() > 0) {
-            throw new ReservationException(DUPLICATE_TIME_RESERVATION);
+            throw new RoomEscapeException(DUPLICATE_TIME_RESERVATION);
         }
         Long id = reservationCount.getAndIncrement();
         Reservation creatteReservation = new Reservation(id, reservation.getDate(), reservation.getTime(), reservation.getName(), reservation.getThemeId());

--- a/src/main/java/nextstep/reservation/repository/MemoryReservationRepository.java
+++ b/src/main/java/nextstep/reservation/repository/MemoryReservationRepository.java
@@ -17,8 +17,8 @@ public class MemoryReservationRepository implements ReservationRepository {
     private static final AtomicLong reservationCount = new AtomicLong(1);
 
     @Override
-    public Reservation create(Reservation reservation) {
-        if (findByDateTime(reservation.getDate(), reservation.getTime())) {
+    public Reservation save(Reservation reservation) {
+        if (findByDateAndTime(reservation.getDate(), reservation.getTime())) {
             throw new ReservationException(DUPLICATE_TIME_RESERVATION);
         }
         Long id = reservationCount.getAndIncrement();
@@ -32,7 +32,7 @@ public class MemoryReservationRepository implements ReservationRepository {
         return reservationList.getOrDefault(id, null);
     }
     @Override
-    public Boolean findByDateTime(LocalDate date, LocalTime time) {
+    public Boolean findByDateAndTime(LocalDate date, LocalTime time) {
         return reservationList
                 .values()
                 .stream()
@@ -40,7 +40,7 @@ public class MemoryReservationRepository implements ReservationRepository {
     }
 
     @Override
-    public Boolean delete(long id) {
+    public Boolean deleteById(long id) {
         if (reservationList.containsKey(id)) {
             reservationList.remove(id);
             return true;

--- a/src/main/java/nextstep/reservation/repository/ReservationRepository.java
+++ b/src/main/java/nextstep/reservation/repository/ReservationRepository.java
@@ -4,15 +4,16 @@ import nextstep.reservation.entity.Reservation;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 public interface ReservationRepository {
     Reservation save(Reservation reservation);
 
     Reservation findById(long id);
 
-    Boolean findByDateAndTime(LocalDate date, LocalTime time);
+    List<Reservation> findByDateAndTime(LocalDate date, LocalTime time);
 
-    Boolean deleteById(long id);
+    int deleteById(long id);
 
     void clear();
 }

--- a/src/main/java/nextstep/reservation/repository/ReservationRepository.java
+++ b/src/main/java/nextstep/reservation/repository/ReservationRepository.java
@@ -5,11 +5,12 @@ import nextstep.reservation.entity.Reservation;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface ReservationRepository {
     Reservation save(Reservation reservation);
 
-    Reservation findById(long id);
+    Optional<Reservation> findById(long id);
 
     List<Reservation> findByDateAndTime(LocalDate date, LocalTime time);
 

--- a/src/main/java/nextstep/reservation/repository/ReservationRepository.java
+++ b/src/main/java/nextstep/reservation/repository/ReservationRepository.java
@@ -6,13 +6,13 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 public interface ReservationRepository {
-    Reservation create(Reservation reservation);
+    Reservation save(Reservation reservation);
 
     Reservation findById(long id);
 
-    Boolean findByDateTime(LocalDate date, LocalTime time);
+    Boolean findByDateAndTime(LocalDate date, LocalTime time);
 
-    Boolean delete(long id);
+    Boolean deleteById(long id);
 
     void clear();
 }

--- a/src/main/java/nextstep/reservation/repository/ThemeRepository.java
+++ b/src/main/java/nextstep/reservation/repository/ThemeRepository.java
@@ -3,13 +3,16 @@ package nextstep.reservation.repository;
 import nextstep.reservation.entity.Theme;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ThemeRepository {
     Theme save(Theme theme);
 
+    Optional<Theme> findById(long id);
+
     List<Theme> findAll();
 
-    int deleteById(Long id);
+    int deleteById(long id);
 
     void clear();
 }

--- a/src/main/java/nextstep/reservation/repository/ThemeRepository.java
+++ b/src/main/java/nextstep/reservation/repository/ThemeRepository.java
@@ -1,0 +1,15 @@
+package nextstep.reservation.repository;
+
+import nextstep.reservation.entity.Theme;
+
+import java.util.List;
+
+public interface ThemeRepository {
+    Theme create(Theme theme);
+
+    List<Theme> findAll();
+
+    int deleteById(Long id);
+
+    void clear();
+}

--- a/src/main/java/nextstep/reservation/repository/ThemeRepository.java
+++ b/src/main/java/nextstep/reservation/repository/ThemeRepository.java
@@ -5,7 +5,7 @@ import nextstep.reservation.entity.Theme;
 import java.util.List;
 
 public interface ThemeRepository {
-    Theme create(Theme theme);
+    Theme save(Theme theme);
 
     List<Theme> findAll();
 

--- a/src/main/java/nextstep/reservation/serializer/ThemeResponseSerializer.java
+++ b/src/main/java/nextstep/reservation/serializer/ThemeResponseSerializer.java
@@ -1,0 +1,26 @@
+package nextstep.reservation.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.util.NameTransformer;
+import nextstep.reservation.dto.ThemeResponse;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class ThemeResponseSerializer extends JsonSerializer<ThemeResponse> {
+
+    private final JsonSerializer<ThemeResponse> delegate = new UnWrappedThemeResponseSerializer(NameTransformer.NOP);
+
+    @Override
+    public void serialize(ThemeResponse themeResponse, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        delegate.serialize(themeResponse, gen, serializers);
+    }
+
+    @Override
+    public JsonSerializer<ThemeResponse> unwrappingSerializer(NameTransformer unwrapper) {
+        return new UnWrappedThemeResponseSerializer(unwrapper);
+    }
+}

--- a/src/main/java/nextstep/reservation/serializer/UnWrappedThemeResponseSerializer.java
+++ b/src/main/java/nextstep/reservation/serializer/UnWrappedThemeResponseSerializer.java
@@ -1,0 +1,32 @@
+package nextstep.reservation.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.util.NameTransformer;
+import nextstep.reservation.dto.ThemeResponse;
+
+import java.io.IOException;
+
+
+public class UnWrappedThemeResponseSerializer extends JsonSerializer<ThemeResponse> {
+    private final NameTransformer nameTransformer;
+
+    public UnWrappedThemeResponseSerializer(NameTransformer nameTransformer) {
+        this.nameTransformer = nameTransformer;
+    }
+
+    @Override
+    public void serialize(ThemeResponse themeResponse, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeStartObject();
+        gen.writeStringField("themeName", themeResponse.getName());
+        gen.writeStringField("themeDesc", themeResponse.getDesc());
+        gen.writeNumberField("themePrice", themeResponse.getPrice());
+        gen.writeEndObject();
+    }
+
+    @Override
+    public boolean isUnwrappingSerializer() {
+        return true;
+    }
+}

--- a/src/main/java/nextstep/reservation/service/ReservationService.java
+++ b/src/main/java/nextstep/reservation/service/ReservationService.java
@@ -5,15 +5,15 @@ import nextstep.reservation.dto.ReservationRequest;
 import nextstep.reservation.dto.ReservationResponse;
 import nextstep.reservation.dto.ThemeResponse;
 import nextstep.reservation.entity.Reservation;
-import nextstep.reservation.exception.ReservationException;
-import nextstep.reservation.exception.ReservationExceptionCode;
+import nextstep.reservation.exception.RoomEscapeException;
+import nextstep.reservation.exception.RoomEscapeExceptionCode;
 import nextstep.reservation.repository.ReservationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
-import static nextstep.reservation.exception.ReservationExceptionCode.DUPLICATE_TIME_RESERVATION;
+import static nextstep.reservation.exception.RoomEscapeExceptionCode.DUPLICATE_TIME_RESERVATION;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +25,7 @@ public class ReservationService {
 
     public ReservationResponse registerReservation(ReservationRequest reservationRequest) {
         if (reservationRepository.findByDateAndTime(reservationRequest.getDate(), reservationRequest.getTime()).size() > 0) {
-            throw new ReservationException(DUPLICATE_TIME_RESERVATION);
+            throw new RoomEscapeException(DUPLICATE_TIME_RESERVATION);
         }
 
         Reservation savedReservation = reservationRepository.save(reservationRequest.toEntity());
@@ -37,7 +37,7 @@ public class ReservationService {
     public ReservationResponse findById(long id) {
         Optional<Reservation> optionalReservation = reservationRepository.findById(id);
         if (optionalReservation.isEmpty()) {
-            throw new ReservationException(ReservationExceptionCode.NO_SUCH_RESERVATION);
+            throw new RoomEscapeException(RoomEscapeExceptionCode.NO_SUCH_RESERVATION);
         }
         Reservation reservation = optionalReservation.get();
         ThemeResponse theme = themeService.findById(reservation.getThemeId());

--- a/src/main/java/nextstep/reservation/service/ReservationService.java
+++ b/src/main/java/nextstep/reservation/service/ReservationService.java
@@ -3,8 +3,8 @@ package nextstep.reservation.service;
 import lombok.RequiredArgsConstructor;
 import nextstep.reservation.dto.ReservationRequest;
 import nextstep.reservation.dto.ReservationResponse;
+import nextstep.reservation.dto.ThemeResponse;
 import nextstep.reservation.entity.Reservation;
-import nextstep.reservation.entity.Theme;
 import nextstep.reservation.exception.ReservationException;
 import nextstep.reservation.exception.ReservationExceptionCode;
 import nextstep.reservation.repository.ReservationRepository;
@@ -29,7 +29,7 @@ public class ReservationService {
         }
 
         Reservation savedReservation = reservationRepository.save(reservationRequest.toEntity());
-        Theme foundedTheme = themeService.findById(savedReservation.getThemeId());
+        ThemeResponse foundedTheme = themeService.findById(savedReservation.getThemeId());
         return ReservationResponse.from(savedReservation, foundedTheme);
     }
 
@@ -40,7 +40,7 @@ public class ReservationService {
             throw new ReservationException(ReservationExceptionCode.NO_SUCH_RESERVATION);
         }
         Reservation reservation = optionalReservation.get();
-        Theme theme = themeService.findById(reservation.getThemeId());
+        ThemeResponse theme = themeService.findById(reservation.getThemeId());
         return ReservationResponse.from(reservation, theme);
     }
 

--- a/src/main/java/nextstep/reservation/service/ReservationService.java
+++ b/src/main/java/nextstep/reservation/service/ReservationService.java
@@ -27,7 +27,8 @@ public class ReservationService {
     }
 
     public Boolean delete(long id) {
-        return reservationRepository.deleteById(id);
+        int deleteRowNumber = reservationRepository.deleteById(id);
+        return deleteRowNumber == 1;
     }
 
     public void clear() {

--- a/src/main/java/nextstep/reservation/service/ReservationService.java
+++ b/src/main/java/nextstep/reservation/service/ReservationService.java
@@ -10,6 +10,7 @@ import nextstep.reservation.repository.ReservationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static nextstep.reservation.constant.RoomEscapeConstant.ENTITY_DELETE_NUMBER;
 import static nextstep.reservation.exception.RoomEscapeExceptionCode.DUPLICATE_TIME_RESERVATION;
 import static nextstep.reservation.exception.RoomEscapeExceptionCode.NO_SUCH_RESERVATION;
 
@@ -41,7 +42,7 @@ public class ReservationService {
 
     public Boolean delete(long id) {
         int deleteRowNumber = reservationRepository.deleteById(id);
-        return deleteRowNumber == 1;
+        return deleteRowNumber == ENTITY_DELETE_NUMBER;
     }
 
     public void clear() {

--- a/src/main/java/nextstep/reservation/service/ReservationService.java
+++ b/src/main/java/nextstep/reservation/service/ReservationService.java
@@ -1,10 +1,16 @@
 package nextstep.reservation.service;
 
 import nextstep.reservation.entity.Reservation;
+import nextstep.reservation.exception.ReservationException;
+import nextstep.reservation.exception.ReservationExceptionCode;
 import nextstep.reservation.repository.ReservationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static nextstep.reservation.exception.ReservationExceptionCode.DUPLICATE_TIME_RESERVATION;
 
 @Service
 @Transactional
@@ -17,13 +23,20 @@ public class ReservationService {
         this.reservationRepository = reservationRepository;
     }
 
-    public Reservation create(Reservation reservation) {
+    public Reservation registerReservation(Reservation reservation) {
+        if (reservationRepository.findByDateAndTime(reservation.getDate(), reservation.getTime()).size() > 0) {
+            throw new ReservationException(DUPLICATE_TIME_RESERVATION);
+        }
         return reservationRepository.save(reservation);
     }
 
     @Transactional(readOnly = true)
     public Reservation findById(long id) {
-        return reservationRepository.findById(id);
+        Optional<Reservation> optionalReservation = reservationRepository.findById(id);
+        if (optionalReservation.isEmpty()) {
+            throw new ReservationException(ReservationExceptionCode.NO_SUCH_RESERVATION);
+        }
+        return optionalReservation.get();
     }
 
     public Boolean delete(long id) {

--- a/src/main/java/nextstep/reservation/service/ReservationService.java
+++ b/src/main/java/nextstep/reservation/service/ReservationService.java
@@ -6,14 +6,12 @@ import nextstep.reservation.dto.ReservationResponse;
 import nextstep.reservation.dto.ThemeResponse;
 import nextstep.reservation.entity.Reservation;
 import nextstep.reservation.exception.RoomEscapeException;
-import nextstep.reservation.exception.RoomEscapeExceptionCode;
 import nextstep.reservation.repository.ReservationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 import static nextstep.reservation.exception.RoomEscapeExceptionCode.DUPLICATE_TIME_RESERVATION;
+import static nextstep.reservation.exception.RoomEscapeExceptionCode.NO_SUCH_RESERVATION;
 
 @Service
 @RequiredArgsConstructor
@@ -35,11 +33,8 @@ public class ReservationService {
 
     @Transactional(readOnly = true)
     public ReservationResponse findById(long id) {
-        Optional<Reservation> optionalReservation = reservationRepository.findById(id);
-        if (optionalReservation.isEmpty()) {
-            throw new RoomEscapeException(RoomEscapeExceptionCode.NO_SUCH_RESERVATION);
-        }
-        Reservation reservation = optionalReservation.get();
+        Reservation reservation = reservationRepository.findById(id)
+                .orElseThrow(() -> new RoomEscapeException(NO_SUCH_RESERVATION));
         ThemeResponse theme = themeService.findById(reservation.getThemeId());
         return ReservationResponse.from(reservation, theme);
     }

--- a/src/main/java/nextstep/reservation/service/ReservationService.java
+++ b/src/main/java/nextstep/reservation/service/ReservationService.java
@@ -4,8 +4,10 @@ import nextstep.reservation.entity.Reservation;
 import nextstep.reservation.repository.ReservationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class ReservationService {
 
     private final ReservationRepository reservationRepository;
@@ -19,6 +21,7 @@ public class ReservationService {
         return reservationRepository.create(reservation);
     }
 
+    @Transactional(readOnly = true)
     public Reservation findById(long id) {
         return reservationRepository.findById(id);
     }

--- a/src/main/java/nextstep/reservation/service/ReservationService.java
+++ b/src/main/java/nextstep/reservation/service/ReservationService.java
@@ -18,7 +18,7 @@ public class ReservationService {
     }
 
     public Reservation create(Reservation reservation) {
-        return reservationRepository.create(reservation);
+        return reservationRepository.save(reservation);
     }
 
     @Transactional(readOnly = true)
@@ -27,7 +27,7 @@ public class ReservationService {
     }
 
     public Boolean delete(long id) {
-        return reservationRepository.delete(id);
+        return reservationRepository.deleteById(id);
     }
 
     public void clear() {

--- a/src/main/java/nextstep/reservation/service/ReservationService.java
+++ b/src/main/java/nextstep/reservation/service/ReservationService.java
@@ -27,7 +27,7 @@ public class ReservationService {
             throw new RoomEscapeException(DUPLICATE_TIME_RESERVATION);
         }
 
-        Reservation savedReservation = reservationRepository.save(reservationRequest.toEntity());
+        Reservation savedReservation = reservationRepository.save(reservationRequest.toEntityWithDummyId());
         ThemeResponse foundedTheme = themeService.findById(savedReservation.getThemeId());
         return ReservationResponse.from(savedReservation, foundedTheme);
     }

--- a/src/main/java/nextstep/reservation/service/ReservationService.java
+++ b/src/main/java/nextstep/reservation/service/ReservationService.java
@@ -1,10 +1,10 @@
 package nextstep.reservation.service;
 
+import lombok.RequiredArgsConstructor;
 import nextstep.reservation.entity.Reservation;
 import nextstep.reservation.exception.ReservationException;
 import nextstep.reservation.exception.ReservationExceptionCode;
 import nextstep.reservation.repository.ReservationRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,15 +13,11 @@ import java.util.Optional;
 import static nextstep.reservation.exception.ReservationExceptionCode.DUPLICATE_TIME_RESERVATION;
 
 @Service
+@RequiredArgsConstructor
 @Transactional
 public class ReservationService {
 
     private final ReservationRepository reservationRepository;
-
-    @Autowired
-    public ReservationService(ReservationRepository reservationRepository) {
-        this.reservationRepository = reservationRepository;
-    }
 
     public Reservation registerReservation(Reservation reservation) {
         if (reservationRepository.findByDateAndTime(reservation.getDate(), reservation.getTime()).size() > 0) {

--- a/src/main/java/nextstep/reservation/service/ThemeService.java
+++ b/src/main/java/nextstep/reservation/service/ThemeService.java
@@ -25,8 +25,9 @@ public class ThemeService {
         return themeRepository.findAll();
     }
 
-    public void deleteById(Long id) {
-        themeRepository.deleteById(id);
+    public boolean deleteById(Long id) {
+        int deletedRowNumber = themeRepository.deleteById(id);
+        return deletedRowNumber == 1;
     }
 
     public void clear() {

--- a/src/main/java/nextstep/reservation/service/ThemeService.java
+++ b/src/main/java/nextstep/reservation/service/ThemeService.java
@@ -3,10 +3,12 @@ package nextstep.reservation.service;
 import nextstep.reservation.entity.Theme;
 import nextstep.reservation.repository.ThemeRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
+@Transactional
 public class ThemeService {
     private final ThemeRepository themeRepository;
 
@@ -18,6 +20,7 @@ public class ThemeService {
         return themeRepository.create(theme);
     }
 
+    @Transactional(readOnly = true)
     public List<Theme> findAll() {
         return themeRepository.findAll();
     }

--- a/src/main/java/nextstep/reservation/service/ThemeService.java
+++ b/src/main/java/nextstep/reservation/service/ThemeService.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static nextstep.reservation.exception.RoomEscapeExceptionCode.NO_SUCH_THEME;
@@ -28,11 +27,8 @@ public class ThemeService {
 
     @Transactional(readOnly = true)
     public ThemeResponse findById(long id) {
-        Optional<Theme> foundedThemeOptional = themeRepository.findById(id);
-        if (foundedThemeOptional.isEmpty()) {
-            throw new RoomEscapeException(NO_SUCH_THEME);
-        }
-        Theme foundedTheme = foundedThemeOptional.get();
+        Theme foundedTheme = themeRepository.findById(id)
+                .orElseThrow(() -> new RoomEscapeException(NO_SUCH_THEME));
         return ThemeResponse.from(foundedTheme);
     }
 

--- a/src/main/java/nextstep/reservation/service/ThemeService.java
+++ b/src/main/java/nextstep/reservation/service/ThemeService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static nextstep.reservation.constant.RoomEscapeConstant.ENTITY_DELETE_NUMBER;
 import static nextstep.reservation.exception.RoomEscapeExceptionCode.NO_SUCH_THEME;
 
 @Service
@@ -42,7 +43,7 @@ public class ThemeService {
 
     public boolean deleteById(long id) {
         int deletedRowNumber = themeRepository.deleteById(id);
-        return deletedRowNumber == 1;
+        return deletedRowNumber == ENTITY_DELETE_NUMBER;
     }
 
     public void clear() {

--- a/src/main/java/nextstep/reservation/service/ThemeService.java
+++ b/src/main/java/nextstep/reservation/service/ThemeService.java
@@ -1,6 +1,8 @@
 package nextstep.reservation.service;
 
 import lombok.RequiredArgsConstructor;
+import nextstep.reservation.dto.ThemeRequest;
+import nextstep.reservation.dto.ThemeResponse;
 import nextstep.reservation.entity.Theme;
 import nextstep.reservation.exception.ReservationException;
 import nextstep.reservation.repository.ThemeRepository;
@@ -9,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static nextstep.reservation.exception.ReservationExceptionCode.NO_SUCH_THEME;
 
@@ -18,22 +21,27 @@ import static nextstep.reservation.exception.ReservationExceptionCode.NO_SUCH_TH
 public class ThemeService {
     private final ThemeRepository themeRepository;
 
-    public Theme create(Theme theme) {
-        return themeRepository.save(theme);
+    public ThemeResponse registerTheme(ThemeRequest themeRequest) {
+        Theme registeredTheme = themeRepository.save(themeRequest.toEntity());
+        return ThemeResponse.from(registeredTheme);
     }
 
     @Transactional(readOnly = true)
-    public Theme findById(long id) {
+    public ThemeResponse findById(long id) {
         Optional<Theme> foundedThemeOptional = themeRepository.findById(id);
         if (foundedThemeOptional.isEmpty()) {
             throw new ReservationException(NO_SUCH_THEME);
         }
-        return foundedThemeOptional.get();
+        Theme foundedTheme = foundedThemeOptional.get();
+        return ThemeResponse.from(foundedTheme);
     }
 
     @Transactional(readOnly = true)
-    public List<Theme> findAll() {
-        return themeRepository.findAll();
+    public List<ThemeResponse> findAll() {
+        List<Theme> allThemes = themeRepository.findAll();
+        return allThemes.stream()
+                .map(ThemeResponse::from)
+                .collect(Collectors.toList());
     }
 
     public boolean deleteById(long id) {

--- a/src/main/java/nextstep/reservation/service/ThemeService.java
+++ b/src/main/java/nextstep/reservation/service/ThemeService.java
@@ -2,11 +2,15 @@ package nextstep.reservation.service;
 
 import lombok.RequiredArgsConstructor;
 import nextstep.reservation.entity.Theme;
+import nextstep.reservation.exception.ReservationException;
 import nextstep.reservation.repository.ThemeRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
+
+import static nextstep.reservation.exception.ReservationExceptionCode.NO_SUCH_THEME;
 
 @Service
 @RequiredArgsConstructor
@@ -19,11 +23,20 @@ public class ThemeService {
     }
 
     @Transactional(readOnly = true)
+    public Theme findById(long id) {
+        Optional<Theme> foundedThemeOptional = themeRepository.findById(id);
+        if (foundedThemeOptional.isEmpty()) {
+            throw new ReservationException(NO_SUCH_THEME);
+        }
+        return foundedThemeOptional.get();
+    }
+
+    @Transactional(readOnly = true)
     public List<Theme> findAll() {
         return themeRepository.findAll();
     }
 
-    public boolean deleteById(Long id) {
+    public boolean deleteById(long id) {
         int deletedRowNumber = themeRepository.deleteById(id);
         return deletedRowNumber == 1;
     }
@@ -31,4 +44,5 @@ public class ThemeService {
     public void clear() {
         themeRepository.clear();
     }
+
 }

--- a/src/main/java/nextstep/reservation/service/ThemeService.java
+++ b/src/main/java/nextstep/reservation/service/ThemeService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import nextstep.reservation.dto.ThemeRequest;
 import nextstep.reservation.dto.ThemeResponse;
 import nextstep.reservation.entity.Theme;
-import nextstep.reservation.exception.ReservationException;
+import nextstep.reservation.exception.RoomEscapeException;
 import nextstep.reservation.repository.ThemeRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static nextstep.reservation.exception.ReservationExceptionCode.NO_SUCH_THEME;
+import static nextstep.reservation.exception.RoomEscapeExceptionCode.NO_SUCH_THEME;
 
 @Service
 @RequiredArgsConstructor
@@ -30,7 +30,7 @@ public class ThemeService {
     public ThemeResponse findById(long id) {
         Optional<Theme> foundedThemeOptional = themeRepository.findById(id);
         if (foundedThemeOptional.isEmpty()) {
-            throw new ReservationException(NO_SUCH_THEME);
+            throw new RoomEscapeException(NO_SUCH_THEME);
         }
         Theme foundedTheme = foundedThemeOptional.get();
         return ThemeResponse.from(foundedTheme);

--- a/src/main/java/nextstep/reservation/service/ThemeService.java
+++ b/src/main/java/nextstep/reservation/service/ThemeService.java
@@ -22,7 +22,7 @@ public class ThemeService {
     private final ThemeRepository themeRepository;
 
     public ThemeResponse registerTheme(ThemeRequest themeRequest) {
-        Theme registeredTheme = themeRepository.save(themeRequest.toEntity());
+        Theme registeredTheme = themeRepository.save(themeRequest.toEntityWithDummyId());
         return ThemeResponse.from(registeredTheme);
     }
 

--- a/src/main/java/nextstep/reservation/service/ThemeService.java
+++ b/src/main/java/nextstep/reservation/service/ThemeService.java
@@ -1,0 +1,32 @@
+package nextstep.reservation.service;
+
+import nextstep.reservation.entity.Theme;
+import nextstep.reservation.repository.ThemeRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ThemeService {
+    private final ThemeRepository themeRepository;
+
+    public ThemeService(ThemeRepository themeRepository) {
+        this.themeRepository = themeRepository;
+    }
+
+    public Theme create(Theme theme) {
+        return themeRepository.create(theme);
+    }
+
+    public List<Theme> findAll() {
+        return themeRepository.findAll();
+    }
+
+    public void deleteById(Long id) {
+        themeRepository.deleteById(id);
+    }
+
+    public void clear() {
+        themeRepository.clear();
+    }
+}

--- a/src/main/java/nextstep/reservation/service/ThemeService.java
+++ b/src/main/java/nextstep/reservation/service/ThemeService.java
@@ -1,5 +1,6 @@
 package nextstep.reservation.service;
 
+import lombok.RequiredArgsConstructor;
 import nextstep.reservation.entity.Theme;
 import nextstep.reservation.repository.ThemeRepository;
 import org.springframework.stereotype.Service;
@@ -8,13 +9,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 @Transactional
 public class ThemeService {
     private final ThemeRepository themeRepository;
-
-    public ThemeService(ThemeRepository themeRepository) {
-        this.themeRepository = themeRepository;
-    }
 
     public Theme create(Theme theme) {
         return themeRepository.save(theme);

--- a/src/main/java/nextstep/reservation/service/ThemeService.java
+++ b/src/main/java/nextstep/reservation/service/ThemeService.java
@@ -17,7 +17,7 @@ public class ThemeService {
     }
 
     public Theme create(Theme theme) {
-        return themeRepository.create(theme);
+        return themeRepository.save(theme);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,5 @@ spring:
 
   sql:
     init:
-      mode: always # 처음 실행할때는 always
-      #      mode: never # 이후에는 never로 변경
+      mode: always
       schema-locations: classpath:schema.sql

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,11 +1,18 @@
-CREATE TABLE RESERVATION
+CREATE TABLE IF NOT EXISTS RESERVATION
 (
     id          bigint not null auto_increment,
-    date        date,
-    time        time,
+    date     date,
+    time     time,
     name        varchar(20),
-    theme_name  varchar(20),
-    theme_desc  varchar(255),
-    theme_price int,
+    theme_id bigint not null,
+    primary key (id)
+);
+
+CREATE TABLE IF NOT EXISTS theme
+(
+    id    bigint not null auto_increment,
+    name  varchar(20),
+    desc  varchar(255),
+    price int,
     primary key (id)
 );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,9 +1,9 @@
 CREATE TABLE IF NOT EXISTS RESERVATION
 (
     id          bigint not null auto_increment,
-    date     date,
-    time     time,
-    name        varchar(20),
+    date     date not null,
+    time     time not null,
+    name        varchar(20) not null,
     theme_id bigint not null,
     primary key (id)
 );
@@ -11,8 +11,8 @@ CREATE TABLE IF NOT EXISTS RESERVATION
 CREATE TABLE IF NOT EXISTS theme
 (
     id    bigint not null auto_increment,
-    name  varchar(20),
-    desc  varchar(255),
-    price int,
+    name  varchar(20) not null,
+    desc  varchar(255) not null,
+    price int not null,
     primary key (id)
 );

--- a/src/test/java/nextstep/reservation/JdbcThemeRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/JdbcThemeRepositoryTest.java
@@ -32,7 +32,7 @@ class JdbcThemeRepositoryTest {
         //given
 
         //when
-        Theme created = jdbcThemeRepository.create(theme);
+        Theme created = jdbcThemeRepository.save(theme);
 
         //then
         assertThat(themeTestEquals(theme, created)).isTrue();
@@ -43,8 +43,8 @@ class JdbcThemeRepositoryTest {
     @DisplayName("전체 조회")
     void findAll() {
         //given
-        Theme created = jdbcThemeRepository.create(theme);
-        Theme created2 = jdbcThemeRepository.create(theme);
+        Theme created = jdbcThemeRepository.save(theme);
+        Theme created2 = jdbcThemeRepository.save(theme);
 
         //when
         List<Theme> founded = jdbcThemeRepository.findAll();
@@ -57,7 +57,7 @@ class JdbcThemeRepositoryTest {
     @DisplayName("id를 통한 삭제")
     void deleteById() {
         //given
-        Theme created = jdbcThemeRepository.create(theme);
+        Theme created = jdbcThemeRepository.save(theme);
 
         //when
         int result = jdbcThemeRepository.deleteById(created.getId());
@@ -70,8 +70,8 @@ class JdbcThemeRepositoryTest {
     @DisplayName("테이블 전체 삭제")
     void clear() {
         //given
-        Theme created = jdbcThemeRepository.create(theme);
-        Theme created2 = jdbcThemeRepository.create(theme);
+        Theme created = jdbcThemeRepository.save(theme);
+        Theme created2 = jdbcThemeRepository.save(theme);
 
         //when
         jdbcThemeRepository.clear();

--- a/src/test/java/nextstep/reservation/JdbcThemeRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/JdbcThemeRepositoryTest.java
@@ -1,0 +1,90 @@
+package nextstep.reservation;
+
+import nextstep.reservation.entity.Theme;
+import nextstep.reservation.repository.JdbcThemeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class JdbcThemeRepositoryTest {
+
+    @Autowired
+    private JdbcThemeRepository jdbcThemeRepository;
+    private Theme theme;
+
+    @BeforeEach
+    void setUp() {
+        this.theme = new Theme(null, "호러", "매우 무서운", 24000);
+    }
+
+    @Test
+    @DisplayName("생성")
+    void create() {
+        //given
+
+        //when
+        Theme created = jdbcThemeRepository.create(theme);
+
+        //then
+        assertThat(themeTestEaquals(theme, created)).isTrue();
+    }
+
+
+    @Test
+    @DisplayName("전체 조회")
+    void findAll() {
+        //given
+        Theme created = jdbcThemeRepository.create(theme);
+        Theme created2 = jdbcThemeRepository.create(theme);
+
+        //when
+        List<Theme> founded = jdbcThemeRepository.findAll();
+
+        //then
+        assertThat(founded).isEqualTo(List.of(created, created2));
+    }
+
+    @Test
+    @DisplayName("id를 통한 삭제")
+    void deleteById() {
+        //given
+        Theme created = jdbcThemeRepository.create(theme);
+
+        //when
+        int result = jdbcThemeRepository.deleteById(created.getId());
+
+        //then
+        assertThat(result).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("테이블 전체 삭제")
+    void clear() {
+        //given
+        Theme created = jdbcThemeRepository.create(theme);
+        Theme created2 = jdbcThemeRepository.create(theme);
+
+        //when
+        jdbcThemeRepository.clear();
+
+        //then
+        int size = jdbcThemeRepository.findAll().size();
+        assertThat(size).isEqualTo(0);
+
+    }
+
+    private boolean themeTestEaquals(Theme a, Theme b) {
+        return a.getName().equals(b.getName()) &&
+                a.getDesc().equals(b.getDesc()) &&
+                a.getPrice().equals(b.getPrice());
+    }
+}

--- a/src/test/java/nextstep/reservation/JdbcThemeRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/JdbcThemeRepositoryTest.java
@@ -35,7 +35,7 @@ class JdbcThemeRepositoryTest {
         Theme created = jdbcThemeRepository.create(theme);
 
         //then
-        assertThat(themeTestEaquals(theme, created)).isTrue();
+        assertThat(themeTestEquals(theme, created)).isTrue();
     }
 
 
@@ -82,7 +82,7 @@ class JdbcThemeRepositoryTest {
 
     }
 
-    private boolean themeTestEaquals(Theme a, Theme b) {
+    private boolean themeTestEquals(Theme a, Theme b) {
         return a.getName().equals(b.getName()) &&
                 a.getDesc().equals(b.getDesc()) &&
                 a.getPrice().equals(b.getPrice());

--- a/src/test/java/nextstep/reservation/JdbcThemeRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/JdbcThemeRepositoryTest.java
@@ -2,6 +2,7 @@ package nextstep.reservation;
 
 import nextstep.reservation.entity.Theme;
 import nextstep.reservation.repository.JdbcThemeRepository;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,6 +38,20 @@ class JdbcThemeRepositoryTest {
 
         //then
         assertThat(themeTestEquals(theme, created)).isTrue();
+    }
+
+    @Test
+    @DisplayName("id를 통한 조회")
+    void findById() {
+        //given
+        Theme created = jdbcThemeRepository.save(theme);
+
+        //when
+        Optional<Theme> foundedThemeOptional = jdbcThemeRepository.findById(created.getId());
+
+        //then
+        Assertions.assertThat(foundedThemeOptional.isPresent()).isTrue();
+        Assertions.assertThat(foundedThemeOptional.get()).isEqualTo(created);
     }
 
 

--- a/src/test/java/nextstep/reservation/ReservationControllerTest.java
+++ b/src/test/java/nextstep/reservation/ReservationControllerTest.java
@@ -39,14 +39,15 @@ public class ReservationControllerTest {
         RestAssured.port = port;
 
         Theme theme = new Theme(null, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
-        themeService.create(theme);
+        Theme createdTheme = themeService.create(theme);
 
-        reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", 1L);
+        reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", createdTheme.getId());
     }
 
     @AfterEach
     void tearDown() {
         reservationService.clear();
+        themeService.clear();
     }
 
     @DisplayName("예약 등록")

--- a/src/test/java/nextstep/reservation/ReservationControllerTest.java
+++ b/src/test/java/nextstep/reservation/ReservationControllerTest.java
@@ -19,7 +19,6 @@ import org.springframework.http.MediaType;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-import static nextstep.reservation.constant.RoomEscapeConstant.DUMMY_ID;
 import static nextstep.reservation.exception.RoomEscapeExceptionCode.DUPLICATE_TIME_RESERVATION;
 import static org.hamcrest.core.Is.is;
 
@@ -48,7 +47,7 @@ public class ReservationControllerTest {
         ThemeRequest themeRequest = new ThemeRequest("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
         ThemeResponse createdTheme = themeService.registerTheme(themeRequest);
 
-        Reservation reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", createdTheme.getId());
+        Reservation reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", createdTheme.getId());
 
         //when
         //then
@@ -68,10 +67,10 @@ public class ReservationControllerTest {
         ThemeRequest themeRequest = new ThemeRequest("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
         ThemeResponse createdTheme = themeService.registerTheme(themeRequest);
 
-        Reservation reservation =  new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", createdTheme.getId());
+        Reservation reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", createdTheme.getId());
         registerReservation(reservation);
 
-        Reservation reservationDuplicated = new Reservation(DUMMY_ID, reservation.getDate(), reservation.getTime(), "name2", reservation.getThemeId());
+        Reservation reservationDuplicated = new Reservation(null, reservation.getDate(), reservation.getTime(), "name2", reservation.getThemeId());
         //when
         //then
         RestAssured.given().log().all()
@@ -92,7 +91,7 @@ public class ReservationControllerTest {
         ThemeRequest themeRequest = new ThemeRequest("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
         ThemeResponse createdTheme = themeService.registerTheme(themeRequest);
 
-        Reservation reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", createdTheme.getId());
+        Reservation reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", createdTheme.getId());
         Response createResponse = registerReservation(reservation);
 
         String id = createResponse.getHeader("Location").split("/")[2]; // Redirect 주소: /reservations/id
@@ -117,7 +116,7 @@ public class ReservationControllerTest {
         ThemeRequest themeRequest = new ThemeRequest("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
         ThemeResponse createdTheme = themeService.registerTheme(themeRequest);
 
-        Reservation reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", createdTheme.getId());
+        Reservation reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", createdTheme.getId());
         Response response = registerReservation(reservation);
 
         String id = response.getHeader("Location").split("/")[2]; // Redirect 주소: /reservations/id

--- a/src/test/java/nextstep/reservation/ReservationControllerTest.java
+++ b/src/test/java/nextstep/reservation/ReservationControllerTest.java
@@ -49,9 +49,9 @@ public class ReservationControllerTest {
         reservationService.clear();
     }
 
-    @DisplayName("예약 생성")
+    @DisplayName("예약 등록")
     @Test
-    void createReservation() {
+    void registerReservation() {
 
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -61,11 +61,11 @@ public class ReservationControllerTest {
                 .statusCode(HttpStatus.CREATED.value());
     }
 
-    @DisplayName("이미 예약이 존재하는 시간에 예약 생성 시도할 때 예외 발생")
+    @DisplayName("이미 예약이 존재하는 시간에 예약 등록 시도할 때 예외 발생")
     @Test
-    void createReservationDuplicate() {
+    void registerReservationDuplicate() {
         Reservation reservationDuplicated = new Reservation(null, reservation.getDate(), reservation.getTime(), "name2", reservation.getThemeId());
-        createReservation(reservation);
+        registerReservation(reservation);
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(reservationDuplicated)
@@ -78,7 +78,7 @@ public class ReservationControllerTest {
     @DisplayName("예약 조회")
     @Test
     void showReservation() {
-        Response createResponse = createReservation(reservation);
+        Response createResponse = registerReservation(reservation);
         String id = createResponse.getHeader("Location").split("/")[2]; // Redirect 주소: /reservations/id
         RestAssured.given().log().all()
                 .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -92,7 +92,7 @@ public class ReservationControllerTest {
     @Test
     @DisplayName("id를 통한 예약 삭제")
     void deleteReservation() {
-        Response response = createReservation(reservation);
+        Response response = registerReservation(reservation);
         String id = response.getHeader("Location").split("/")[2]; // Redirect 주소: /reservations/id
         RestAssured.given().log().all()
                 .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -111,7 +111,7 @@ public class ReservationControllerTest {
                 .statusCode(HttpStatus.NO_CONTENT.value());
     }
 
-    private Response createReservation(Reservation reservation) {
+    private Response registerReservation(Reservation reservation) {
         return RestAssured
                 .given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/nextstep/reservation/ReservationControllerTest.java
+++ b/src/test/java/nextstep/reservation/ReservationControllerTest.java
@@ -50,7 +50,7 @@ public class ReservationControllerTest {
         themeService.clear();
     }
 
-    @DisplayName("예약 등록")
+    @DisplayName("예약 등록시 201이 반환되며 /reservations/{id}로 이동한다.")
     @Test
     void registerReservation() {
 
@@ -62,7 +62,7 @@ public class ReservationControllerTest {
                 .statusCode(HttpStatus.CREATED.value());
     }
 
-    @DisplayName("이미 예약이 존재하는 시간에 예약 등록 시도할 때 예외 발생")
+    @DisplayName("이미 예약이 존재하는 시간에 예약 등록 시도할 때 예외 발생한다.")
     @Test
     void registerReservationDuplicate() {
         Reservation reservationDuplicated = new Reservation(null, reservation.getDate(), reservation.getTime(), "name2", reservation.getThemeId());
@@ -76,7 +76,7 @@ public class ReservationControllerTest {
                 .body(is(DUPLICATE_TIME_RESERVATION.getMessage()));
     }
 
-    @DisplayName("예약 조회")
+    @DisplayName("예약 조회시 body에 예약 정보가 정해진 형식으로 주어진다.")
     @Test
     void showReservation() {
         Response createResponse = registerReservation(reservation);
@@ -91,7 +91,7 @@ public class ReservationControllerTest {
     }
 
     @Test
-    @DisplayName("id를 통한 예약 삭제")
+    @DisplayName("id를 통한 예약 삭제시 204를 반환한다.")
     void deleteReservation() {
         Response response = registerReservation(reservation);
         String id = response.getHeader("Location").split("/")[2]; // Redirect 주소: /reservations/id
@@ -103,7 +103,7 @@ public class ReservationControllerTest {
     }
 
     @Test
-    @DisplayName("예약 전체 삭제")
+    @DisplayName("예약 전체 삭제시 204를 반환한다.")
     void clearAll() {
         RestAssured.given().log().all()
                 .accept(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/nextstep/reservation/ReservationControllerTest.java
+++ b/src/test/java/nextstep/reservation/ReservationControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.http.MediaType;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+import static nextstep.reservation.constant.RoomEscapeConstant.DUMMY_ID;
 import static nextstep.reservation.exception.RoomEscapeExceptionCode.DUPLICATE_TIME_RESERVATION;
 import static org.hamcrest.core.Is.is;
 
@@ -41,7 +42,7 @@ public class ReservationControllerTest {
         ThemeRequest themeRequest = new ThemeRequest("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
         ThemeResponse createdTheme = themeService.registerTheme(themeRequest);
 
-        reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", createdTheme.getId());
+        reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", createdTheme.getId());
     }
 
     @AfterEach
@@ -65,7 +66,7 @@ public class ReservationControllerTest {
     @DisplayName("이미 예약이 존재하는 시간에 예약 등록 시도할 때 예외 발생한다.")
     @Test
     void registerReservationDuplicate() {
-        Reservation reservationDuplicated = new Reservation(null, reservation.getDate(), reservation.getTime(), "name2", reservation.getThemeId());
+        Reservation reservationDuplicated = new Reservation(DUMMY_ID, reservation.getDate(), reservation.getTime(), "name2", reservation.getThemeId());
         registerReservation(reservation);
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/nextstep/reservation/ReservationControllerTest.java
+++ b/src/test/java/nextstep/reservation/ReservationControllerTest.java
@@ -1,118 +1,124 @@
-//package nextstep.reservation;
-//
-//import io.restassured.RestAssured;
-//import io.restassured.response.Response;
-//import nextstep.reservation.entity.Reservation;
-//import nextstep.reservation.entity.Theme;
-//import nextstep.reservation.service.ReservationService;
-//import org.junit.jupiter.api.AfterEach;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.context.SpringBootTest;
-//import org.springframework.boot.web.server.LocalServerPort;
-//import org.springframework.http.HttpStatus;
-//import org.springframework.http.MediaType;
-//
-//import java.time.LocalDate;
-//import java.time.LocalTime;
-//import java.time.format.DateTimeFormatter;
-//
-//import static nextstep.reservation.exception.ReservationExceptionCode.DUPLICATE_TIME_RESERVATION;
-//import static org.hamcrest.core.Is.is;
-//
-//@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-//public class ReservationControllerTest {
-//
-//    @LocalServerPort
-//    int port;
-//    @Autowired
-//    private ReservationService reservationService;
-//    private Reservation reservation;
-//
-//    @BeforeEach
-//    void setUp() {
-//        RestAssured.port = port;
-//        Theme theme = new Theme("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
-//        reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", theme);
-//    }
-//
-//    @AfterEach
-//    void tearDown() {
-//        reservationService.clear();
-//    }
-//
-//    @DisplayName("예약 생성")
-//    @Test
-//    void createReservation() {
-//
-//        RestAssured.given().log().all()
-//                .contentType(MediaType.APPLICATION_JSON_VALUE)
-//                .body(reservation)
-//                .when().post("/reservations")
-//                .then().log().all()
-//                .statusCode(HttpStatus.CREATED.value());
-//    }
-//
-//    @DisplayName("이미 예약이 존재하는 시간에 예약 생성 시도할 때 예외 발생")
-//    @Test
-//    void createReservationDuplicate() {
-//        Reservation reservationDuplicated = new Reservation(null, reservation.getDate(), reservation.getTime(), "name2", reservation.getTheme());
-//        createReservation(reservation);
-//        RestAssured.given().log().all()
-//                .contentType(MediaType.APPLICATION_JSON_VALUE)
-//                .body(reservationDuplicated)
-//                .when().post("/reservations")
-//                .then().log().all()
-//                .statusCode(HttpStatus.BAD_REQUEST.value())
-//                .body(is(DUPLICATE_TIME_RESERVATION.getMessage()));
-//    }
-//
-//    @DisplayName("예약 조회")
-//    @Test
-//    void showReservation() {
-//        Response createResponse = createReservation(reservation);
-//        String id = createResponse.getHeader("Location").split("/")[2]; // Redirect 주소: /reservations/id
-//        RestAssured.given().log().all()
-//                .accept(MediaType.APPLICATION_JSON_VALUE)
-//                .when().get("/reservations/" + id)
-//                .then().log().all()
-//                .statusCode(HttpStatus.OK.value())
-//                .body("date", is(reservation.getDate().toString()))
-//                .body("time", is(reservation.getTime().format(DateTimeFormatter.ofPattern("HH:mm:ss"))));
-//    }
-//
-//    @Test
-//    @DisplayName("id를 통한 예약 삭제")
-//    void deleteReservation() {
-//        Response response = createReservation(reservation);
-//        String id = response.getHeader("Location").split("/")[2]; // Redirect 주소: /reservations/id
-//        RestAssured.given().log().all()
-//                .accept(MediaType.APPLICATION_JSON_VALUE)
-//                .when().delete("/reservations/" + id)
-//                .then().log().all()
-//                .statusCode(HttpStatus.NO_CONTENT.value());
-//    }
-//
-//    @Test
-//    @DisplayName("예약 전체 삭제")
-//    void clearAll() {
-//        RestAssured.given().log().all()
-//                .accept(MediaType.APPLICATION_JSON_VALUE)
-//                .when().delete("/reservations")
-//                .then().log().all()
-//                .statusCode(HttpStatus.NO_CONTENT.value());
-//    }
-//
-//    private Response createReservation(Reservation reservation) {
-//        return RestAssured
-//                .given().log().all()
-//                .contentType(MediaType.APPLICATION_JSON_VALUE)
-//                .body(reservation)
-//                .when().post("/reservations")
-//                .then().log().all()
-//                .extract()
-//                .response();
-//    }
-//}
+package nextstep.reservation;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import nextstep.reservation.entity.Reservation;
+import nextstep.reservation.entity.Theme;
+import nextstep.reservation.service.ReservationService;
+import nextstep.reservation.service.ThemeService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+import static nextstep.reservation.exception.ReservationExceptionCode.DUPLICATE_TIME_RESERVATION;
+import static org.hamcrest.core.Is.is;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ReservationControllerTest {
+
+    @LocalServerPort
+    int port;
+    @Autowired
+    private ReservationService reservationService;
+    @Autowired
+    private ThemeService themeService;
+    private Reservation reservation;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+
+        Theme theme = new Theme(null, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        themeService.create(theme);
+
+        reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", 1L);
+    }
+
+    @AfterEach
+    void tearDown() {
+        reservationService.clear();
+    }
+
+    @DisplayName("예약 생성")
+    @Test
+    void createReservation() {
+
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(reservation)
+                .when().post("/reservations")
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
+    @DisplayName("이미 예약이 존재하는 시간에 예약 생성 시도할 때 예외 발생")
+    @Test
+    void createReservationDuplicate() {
+        Reservation reservationDuplicated = new Reservation(null, reservation.getDate(), reservation.getTime(), "name2", reservation.getThemeId());
+        createReservation(reservation);
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(reservationDuplicated)
+                .when().post("/reservations")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body(is(DUPLICATE_TIME_RESERVATION.getMessage()));
+    }
+
+    @DisplayName("예약 조회")
+    @Test
+    void showReservation() {
+        Response createResponse = createReservation(reservation);
+        String id = createResponse.getHeader("Location").split("/")[2]; // Redirect 주소: /reservations/id
+        RestAssured.given().log().all()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/reservations/" + id)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .body("date", is(reservation.getDate().toString()))
+                .body("time", is(reservation.getTime().format(DateTimeFormatter.ofPattern("HH:mm:ss"))));
+    }
+
+    @Test
+    @DisplayName("id를 통한 예약 삭제")
+    void deleteReservation() {
+        Response response = createReservation(reservation);
+        String id = response.getHeader("Location").split("/")[2]; // Redirect 주소: /reservations/id
+        RestAssured.given().log().all()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().delete("/reservations/" + id)
+                .then().log().all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    @DisplayName("예약 전체 삭제")
+    void clearAll() {
+        RestAssured.given().log().all()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().delete("/reservations")
+                .then().log().all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    private Response createReservation(Reservation reservation) {
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(reservation)
+                .when().post("/reservations")
+                .then().log().all()
+                .extract()
+                .response();
+    }
+}

--- a/src/test/java/nextstep/reservation/ReservationControllerTest.java
+++ b/src/test/java/nextstep/reservation/ReservationControllerTest.java
@@ -8,7 +8,6 @@ import nextstep.reservation.entity.Reservation;
 import nextstep.reservation.service.ReservationService;
 import nextstep.reservation.service.ThemeService;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,17 +32,6 @@ public class ReservationControllerTest {
     private ReservationService reservationService;
     @Autowired
     private ThemeService themeService;
-    private Reservation reservation;
-
-    @BeforeEach
-    void setUp() {
-        RestAssured.port = port;
-
-        ThemeRequest themeRequest = new ThemeRequest("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
-        ThemeResponse createdTheme = themeService.registerTheme(themeRequest);
-
-        reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", createdTheme.getId());
-    }
 
     @AfterEach
     void tearDown() {
@@ -54,7 +42,16 @@ public class ReservationControllerTest {
     @DisplayName("예약 등록시 201이 반환되며 /reservations/{id}로 이동한다.")
     @Test
     void registerReservation() {
+        //given
+        RestAssured.port = port;
 
+        ThemeRequest themeRequest = new ThemeRequest("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        ThemeResponse createdTheme = themeService.registerTheme(themeRequest);
+
+        Reservation reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", createdTheme.getId());
+
+        //when
+        //then
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(reservation)
@@ -66,8 +63,17 @@ public class ReservationControllerTest {
     @DisplayName("이미 예약이 존재하는 시간에 예약 등록 시도할 때 예외 발생한다.")
     @Test
     void registerReservationDuplicate() {
-        Reservation reservationDuplicated = new Reservation(DUMMY_ID, reservation.getDate(), reservation.getTime(), "name2", reservation.getThemeId());
+        //given
+        RestAssured.port = port;
+        ThemeRequest themeRequest = new ThemeRequest("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        ThemeResponse createdTheme = themeService.registerTheme(themeRequest);
+
+        Reservation reservation =  new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", createdTheme.getId());
         registerReservation(reservation);
+
+        Reservation reservationDuplicated = new Reservation(DUMMY_ID, reservation.getDate(), reservation.getTime(), "name2", reservation.getThemeId());
+        //when
+        //then
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(reservationDuplicated)
@@ -80,8 +86,19 @@ public class ReservationControllerTest {
     @DisplayName("예약 조회시 body에 예약 정보가 정해진 형식으로 주어진다.")
     @Test
     void showReservation() {
+        //given
+        RestAssured.port = port;
+
+        ThemeRequest themeRequest = new ThemeRequest("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        ThemeResponse createdTheme = themeService.registerTheme(themeRequest);
+
+        Reservation reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", createdTheme.getId());
         Response createResponse = registerReservation(reservation);
+
         String id = createResponse.getHeader("Location").split("/")[2]; // Redirect 주소: /reservations/id
+
+        //when
+        //then
         RestAssured.given().log().all()
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/reservations/" + id)
@@ -94,8 +111,19 @@ public class ReservationControllerTest {
     @Test
     @DisplayName("id를 통한 예약 삭제시 204를 반환한다.")
     void deleteReservation() {
+        //given
+        RestAssured.port = port;
+
+        ThemeRequest themeRequest = new ThemeRequest("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        ThemeResponse createdTheme = themeService.registerTheme(themeRequest);
+
+        Reservation reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", createdTheme.getId());
         Response response = registerReservation(reservation);
+
         String id = response.getHeader("Location").split("/")[2]; // Redirect 주소: /reservations/id
+
+        //when
+        //then
         RestAssured.given().log().all()
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .when().delete("/reservations/" + id)
@@ -106,6 +134,11 @@ public class ReservationControllerTest {
     @Test
     @DisplayName("예약 전체 삭제시 204를 반환한다.")
     void clearAll() {
+        //given
+        RestAssured.port = port;
+
+        //when
+        //then
         RestAssured.given().log().all()
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .when().delete("/reservations")

--- a/src/test/java/nextstep/reservation/ReservationControllerTest.java
+++ b/src/test/java/nextstep/reservation/ReservationControllerTest.java
@@ -2,8 +2,9 @@ package nextstep.reservation;
 
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
+import nextstep.reservation.dto.ThemeRequest;
+import nextstep.reservation.dto.ThemeResponse;
 import nextstep.reservation.entity.Reservation;
-import nextstep.reservation.entity.Theme;
 import nextstep.reservation.service.ReservationService;
 import nextstep.reservation.service.ThemeService;
 import org.junit.jupiter.api.AfterEach;
@@ -38,8 +39,8 @@ public class ReservationControllerTest {
     void setUp() {
         RestAssured.port = port;
 
-        Theme theme = new Theme(null, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
-        Theme createdTheme = themeService.create(theme);
+        ThemeRequest themeRequest = new ThemeRequest("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        ThemeResponse createdTheme = themeService.registerTheme(themeRequest);
 
         reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", createdTheme.getId());
     }

--- a/src/test/java/nextstep/reservation/ReservationControllerTest.java
+++ b/src/test/java/nextstep/reservation/ReservationControllerTest.java
@@ -19,7 +19,6 @@ import org.springframework.http.MediaType;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 
 import static nextstep.reservation.exception.RoomEscapeExceptionCode.DUPLICATE_TIME_RESERVATION;
 import static org.hamcrest.core.Is.is;
@@ -88,7 +87,7 @@ public class ReservationControllerTest {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .body("date", is(reservation.getDate().toString()))
-                .body("time", is(reservation.getTime().format(DateTimeFormatter.ofPattern("HH:mm:ss"))));
+                .body("time", is(reservation.getTime().toString()));
     }
 
     @Test

--- a/src/test/java/nextstep/reservation/ReservationControllerTest.java
+++ b/src/test/java/nextstep/reservation/ReservationControllerTest.java
@@ -21,7 +21,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
-import static nextstep.reservation.exception.ReservationExceptionCode.DUPLICATE_TIME_RESERVATION;
+import static nextstep.reservation.exception.RoomEscapeExceptionCode.DUPLICATE_TIME_RESERVATION;
 import static org.hamcrest.core.Is.is;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)

--- a/src/test/java/nextstep/reservation/ReservationControllerTest.java
+++ b/src/test/java/nextstep/reservation/ReservationControllerTest.java
@@ -1,118 +1,118 @@
-package nextstep.reservation;
-
-import io.restassured.RestAssured;
-import io.restassured.response.Response;
-import nextstep.reservation.entity.Reservation;
-import nextstep.reservation.entity.Theme;
-import nextstep.reservation.service.ReservationService;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-
-import static nextstep.reservation.exception.ReservationExceptionCode.DUPLICATE_TIME_RESERVATION;
-import static org.hamcrest.core.Is.is;
-
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class ReservationControllerTest {
-
-    @LocalServerPort
-    int port;
-    @Autowired
-    private ReservationService reservationService;
-    private Reservation reservation;
-
-    @BeforeEach
-    void setUp() {
-        RestAssured.port = port;
-        Theme theme = new Theme("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
-        reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", theme);
-    }
-
-    @AfterEach
-    void tearDown() {
-        reservationService.clear();
-    }
-
-    @DisplayName("예약 생성")
-    @Test
-    void createReservation() {
-
-        RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(reservation)
-                .when().post("/reservations")
-                .then().log().all()
-                .statusCode(HttpStatus.CREATED.value());
-    }
-
-    @DisplayName("이미 예약이 존재하는 시간에 예약 생성 시도할 때 예외 발생")
-    @Test
-    void createReservationDuplicate() {
-        Reservation reservationDuplicated = new Reservation(null, reservation.getDate(), reservation.getTime(), "name2", reservation.getTheme());
-        createReservation(reservation);
-        RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(reservationDuplicated)
-                .when().post("/reservations")
-                .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value())
-                .body(is(DUPLICATE_TIME_RESERVATION.getMessage()));
-    }
-
-    @DisplayName("예약 조회")
-    @Test
-    void showReservation() {
-        Response createResponse = createReservation(reservation);
-        String id = createResponse.getHeader("Location").split("/")[2]; // Redirect 주소: /reservations/id
-        RestAssured.given().log().all()
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/reservations/" + id)
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .body("date", is(reservation.getDate().toString()))
-                .body("time", is(reservation.getTime().format(DateTimeFormatter.ofPattern("HH:mm:ss"))));
-    }
-
-    @Test
-    @DisplayName("id를 통한 예약 삭제")
-    void deleteReservation() {
-        Response response = createReservation(reservation);
-        String id = response.getHeader("Location").split("/")[2]; // Redirect 주소: /reservations/id
-        RestAssured.given().log().all()
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .when().delete("/reservations/" + id)
-                .then().log().all()
-                .statusCode(HttpStatus.NO_CONTENT.value());
-    }
-
-    @Test
-    @DisplayName("예약 전체 삭제")
-    void clearAll() {
-        RestAssured.given().log().all()
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .when().delete("/reservations")
-                .then().log().all()
-                .statusCode(HttpStatus.NO_CONTENT.value());
-    }
-
-    private Response createReservation(Reservation reservation) {
-        return RestAssured
-                .given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(reservation)
-                .when().post("/reservations")
-                .then().log().all()
-                .extract()
-                .response();
-    }
-}
+//package nextstep.reservation;
+//
+//import io.restassured.RestAssured;
+//import io.restassured.response.Response;
+//import nextstep.reservation.entity.Reservation;
+//import nextstep.reservation.entity.Theme;
+//import nextstep.reservation.service.ReservationService;
+//import org.junit.jupiter.api.AfterEach;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.boot.web.server.LocalServerPort;
+//import org.springframework.http.HttpStatus;
+//import org.springframework.http.MediaType;
+//
+//import java.time.LocalDate;
+//import java.time.LocalTime;
+//import java.time.format.DateTimeFormatter;
+//
+//import static nextstep.reservation.exception.ReservationExceptionCode.DUPLICATE_TIME_RESERVATION;
+//import static org.hamcrest.core.Is.is;
+//
+//@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+//public class ReservationControllerTest {
+//
+//    @LocalServerPort
+//    int port;
+//    @Autowired
+//    private ReservationService reservationService;
+//    private Reservation reservation;
+//
+//    @BeforeEach
+//    void setUp() {
+//        RestAssured.port = port;
+//        Theme theme = new Theme("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+//        reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", theme);
+//    }
+//
+//    @AfterEach
+//    void tearDown() {
+//        reservationService.clear();
+//    }
+//
+//    @DisplayName("예약 생성")
+//    @Test
+//    void createReservation() {
+//
+//        RestAssured.given().log().all()
+//                .contentType(MediaType.APPLICATION_JSON_VALUE)
+//                .body(reservation)
+//                .when().post("/reservations")
+//                .then().log().all()
+//                .statusCode(HttpStatus.CREATED.value());
+//    }
+//
+//    @DisplayName("이미 예약이 존재하는 시간에 예약 생성 시도할 때 예외 발생")
+//    @Test
+//    void createReservationDuplicate() {
+//        Reservation reservationDuplicated = new Reservation(null, reservation.getDate(), reservation.getTime(), "name2", reservation.getTheme());
+//        createReservation(reservation);
+//        RestAssured.given().log().all()
+//                .contentType(MediaType.APPLICATION_JSON_VALUE)
+//                .body(reservationDuplicated)
+//                .when().post("/reservations")
+//                .then().log().all()
+//                .statusCode(HttpStatus.BAD_REQUEST.value())
+//                .body(is(DUPLICATE_TIME_RESERVATION.getMessage()));
+//    }
+//
+//    @DisplayName("예약 조회")
+//    @Test
+//    void showReservation() {
+//        Response createResponse = createReservation(reservation);
+//        String id = createResponse.getHeader("Location").split("/")[2]; // Redirect 주소: /reservations/id
+//        RestAssured.given().log().all()
+//                .accept(MediaType.APPLICATION_JSON_VALUE)
+//                .when().get("/reservations/" + id)
+//                .then().log().all()
+//                .statusCode(HttpStatus.OK.value())
+//                .body("date", is(reservation.getDate().toString()))
+//                .body("time", is(reservation.getTime().format(DateTimeFormatter.ofPattern("HH:mm:ss"))));
+//    }
+//
+//    @Test
+//    @DisplayName("id를 통한 예약 삭제")
+//    void deleteReservation() {
+//        Response response = createReservation(reservation);
+//        String id = response.getHeader("Location").split("/")[2]; // Redirect 주소: /reservations/id
+//        RestAssured.given().log().all()
+//                .accept(MediaType.APPLICATION_JSON_VALUE)
+//                .when().delete("/reservations/" + id)
+//                .then().log().all()
+//                .statusCode(HttpStatus.NO_CONTENT.value());
+//    }
+//
+//    @Test
+//    @DisplayName("예약 전체 삭제")
+//    void clearAll() {
+//        RestAssured.given().log().all()
+//                .accept(MediaType.APPLICATION_JSON_VALUE)
+//                .when().delete("/reservations")
+//                .then().log().all()
+//                .statusCode(HttpStatus.NO_CONTENT.value());
+//    }
+//
+//    private Response createReservation(Reservation reservation) {
+//        return RestAssured
+//                .given().log().all()
+//                .contentType(MediaType.APPLICATION_JSON_VALUE)
+//                .body(reservation)
+//                .when().post("/reservations")
+//                .then().log().all()
+//                .extract()
+//                .response();
+//    }
+//}

--- a/src/test/java/nextstep/reservation/ReservationControllerTest.java
+++ b/src/test/java/nextstep/reservation/ReservationControllerTest.java
@@ -30,14 +30,12 @@ public class ReservationControllerTest {
     @Autowired
     private ReservationService reservationService;
     private Reservation reservation;
-    private Reservation reservationDuplicated;
 
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
         Theme theme = new Theme("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
         reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", theme);
-        reservationDuplicated = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name2", theme);
     }
 
     @AfterEach
@@ -60,6 +58,7 @@ public class ReservationControllerTest {
     @DisplayName("이미 예약이 존재하는 시간에 예약 생성 시도할 때 예외 발생")
     @Test
     void createReservationDuplicate() {
+        Reservation reservationDuplicated = new Reservation(null, reservation.getDate(), reservation.getTime(), "name2", reservation.getTheme());
         createReservation(reservation);
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
@@ -43,8 +43,8 @@ class ReservationRepositoryTest {
     @Test
     @DisplayName("예약 삽입")
     void createReservationTest() {
-        Reservation result = reservationRepository.create(reservation);
-        assertThat(result).isEqualTo(reservation);
+        Reservation created = reservationRepository.create(reservation);
+        assertThat(reservationDataEquals(created, reservation)).isTrue();
     }
 
     @Test
@@ -90,5 +90,12 @@ class ReservationRepositoryTest {
                 () -> reservationRepository.findById(created.getId()))
                 .isInstanceOf(ReservationException.class)
                 .hasMessage(NO_SUCH_RESERVATION.getMessage());
+    }
+
+    private boolean reservationDataEquals(Reservation a, Reservation b) {
+        return a.getName().equals(b.getName()) &&
+                a.getDate().equals(b.getDate()) &&
+                a.getTime().equals(b.getTime()) &&
+                a.getThemeId().equals(b.getThemeId());
     }
 }

--- a/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
@@ -18,7 +18,6 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
-import static nextstep.reservation.constant.RoomEscapeConstant.DUMMY_ID;
 import static nextstep.reservation.exception.RoomEscapeExceptionCode.NO_SUCH_THEME;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,10 +40,10 @@ class ReservationRepositoryTest {
     void createReservationTest() {
 
         //given
-        Theme theme = new Theme(DUMMY_ID, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        Theme theme = new Theme(null, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
         Theme savedTheme = themeRepository.save(theme);
 
-        Reservation reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", savedTheme.getId());
+        Reservation reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", savedTheme.getId());
 
         //when
         Reservation created = reservationRepository.save(reservation);
@@ -58,7 +57,7 @@ class ReservationRepositoryTest {
     void deleteReservationFail() {
 
         //given
-        Reservation invalidReservation = new Reservation(DUMMY_ID, LocalDate.parse("2023-01-16"), LocalTime.parse("19:20"), "herbi", 1234L);
+        Reservation invalidReservation = new Reservation(null, LocalDate.parse("2023-01-16"), LocalTime.parse("19:20"), "herbi", 1234L);
 
         //when
         //then
@@ -71,10 +70,10 @@ class ReservationRepositoryTest {
     @DisplayName("예약 ID로 조회 성공")
     void findByIdTest() {
         //given
-        Theme theme = new Theme(DUMMY_ID, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        Theme theme = new Theme(null, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
         Theme savedTheme = themeRepository.save(theme);
 
-        Reservation reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", savedTheme.getId());
+        Reservation reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", savedTheme.getId());
         Reservation created = reservationRepository.save(reservation);
 
         //when
@@ -89,10 +88,10 @@ class ReservationRepositoryTest {
     @DisplayName("날짜/시간으로 예약 존재 여부 조회(예약 있을 때)")
     void findByDateTimeTest() {
         //given
-        Theme theme = new Theme(DUMMY_ID, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        Theme theme = new Theme(null, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
         Theme savedTheme = themeRepository.save(theme);
 
-        Reservation reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", savedTheme.getId());
+        Reservation reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", savedTheme.getId());
         reservationRepository.save(reservation);
 
         //when
@@ -119,10 +118,10 @@ class ReservationRepositoryTest {
     void deleteReservation() {
 
         //given
-        Theme theme = new Theme(DUMMY_ID, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        Theme theme = new Theme(null, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
         Theme savedTheme = themeRepository.save(theme);
 
-        Reservation reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", savedTheme.getId());
+        Reservation reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", savedTheme.getId());
         Reservation created = reservationRepository.save(reservation);
 
         //when

--- a/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
@@ -15,7 +15,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+import static nextstep.reservation.exception.ReservationExceptionCode.NO_SUCH_RESERVATION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 @SpringBootTest
@@ -83,7 +85,9 @@ class ReservationRepositoryTest {
         Boolean result = reservationRepository.delete(created.getId());
         assertThat(result).isEqualTo(true);
 
-        Reservation findResult = reservationRepository.findById(created.getId());
-        assertThat(findResult).isNull();
+        assertThatThrownBy(
+                () -> reservationRepository.findById(created.getId()))
+                .isInstanceOf(ReservationException.class)
+                .hasMessage(NO_SUCH_RESERVATION.getMessage());
     }
 }

--- a/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
@@ -19,6 +19,7 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
+import static nextstep.reservation.constant.RoomEscapeConstant.DUMMY_ID;
 import static nextstep.reservation.exception.RoomEscapeExceptionCode.NO_SUCH_THEME;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,10 +35,10 @@ class ReservationRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        Theme theme = new Theme(null, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        Theme theme = new Theme(DUMMY_ID, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
         Theme savedTheme = themeRepository.save(theme);
 
-        this.reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", savedTheme.getId());
+        this.reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", savedTheme.getId());
     }
 
     @AfterEach
@@ -63,7 +64,7 @@ class ReservationRepositoryTest {
     void deleteReservationFail() {
 
         //given
-        Reservation invalidReservation = new Reservation(null, LocalDate.parse("2023-01-16"), LocalTime.parse("19:20"), "herbi", 1234L);
+        Reservation invalidReservation = new Reservation(DUMMY_ID, LocalDate.parse("2023-01-16"), LocalTime.parse("19:20"), "herbi", 1234L);
 
         //when
         //then

--- a/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
@@ -37,17 +37,28 @@ class ReservationRepositoryTest {
     }
 
     @Test
-    @DisplayName("예약 삽입")
+    @DisplayName("예약 삽입 성공")
     void createReservationTest() {
+
+        //given
+
+        //when
         Reservation created = reservationRepository.save(reservation);
+
+        //then
         assertThat(reservationDataEquals(created, reservation)).isTrue();
     }
 
     @Test
-    @DisplayName("예약 ID로 조회")
+    @DisplayName("예약 ID로 조회 성공")
     void findByIdTest() {
+        //given
         Reservation created = reservationRepository.save(reservation);
+
+        //when
         Optional<Reservation> result = reservationRepository.findById(created.getId());
+
+        //then
         assertThat(result.isPresent()).isTrue();
         assertThat(result.get()).isEqualTo(created);
     }
@@ -55,23 +66,39 @@ class ReservationRepositoryTest {
     @Test
     @DisplayName("날짜/시간으로 예약 존재 여부 조회(예약 있을 때)")
     void findByDateTimeTest() {
+        //given
         reservationRepository.save(reservation);
+
+        //when
         List<Reservation> result = reservationRepository.findByDateAndTime(reservation.getDate(), reservation.getTime());
+
+        //then
         assertThat(reservationDataEquals(reservation, result.get(0))).isTrue();
     }
 
     @Test
     @DisplayName("날짜/시간으로 예약 존재 여부 조회(예약 없을 때")
     void findByDateTimeEmptyTest() {
+        //given
+
+        //when
         List<Reservation> result = reservationRepository.findByDateAndTime(LocalDate.parse("2022-08-14"), LocalTime.parse("13:00"));
+
+        //then
         assertThat(result).isEqualTo(List.of());
     }
 
     @Test
-    @DisplayName("예약 삭제")
+    @DisplayName("예약 삭제 성공")
     void deleteReservation() {
+
+        //given
         Reservation created = reservationRepository.save(reservation);
+
+        //when
         int result = reservationRepository.deleteById(created.getId());
+
+        //then
         assertThat(result).isEqualTo(1);
 
         Optional<Reservation> deletedReservationOptional = reservationRepository.findById(created.getId());

--- a/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
@@ -7,7 +7,6 @@ import nextstep.reservation.repository.ReservationRepository;
 import nextstep.reservation.repository.ThemeRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,15 +30,6 @@ class ReservationRepositoryTest {
     private ReservationRepository reservationRepository;
     @Autowired
     private ThemeRepository themeRepository;
-    private Reservation reservation;
-
-    @BeforeEach
-    void setUp() {
-        Theme theme = new Theme(DUMMY_ID, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
-        Theme savedTheme = themeRepository.save(theme);
-
-        this.reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", savedTheme.getId());
-    }
 
     @AfterEach
     void tearDown() {
@@ -51,6 +41,10 @@ class ReservationRepositoryTest {
     void createReservationTest() {
 
         //given
+        Theme theme = new Theme(DUMMY_ID, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        Theme savedTheme = themeRepository.save(theme);
+
+        Reservation reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", savedTheme.getId());
 
         //when
         Reservation created = reservationRepository.save(reservation);
@@ -77,6 +71,10 @@ class ReservationRepositoryTest {
     @DisplayName("예약 ID로 조회 성공")
     void findByIdTest() {
         //given
+        Theme theme = new Theme(DUMMY_ID, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        Theme savedTheme = themeRepository.save(theme);
+
+        Reservation reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", savedTheme.getId());
         Reservation created = reservationRepository.save(reservation);
 
         //when
@@ -91,6 +89,10 @@ class ReservationRepositoryTest {
     @DisplayName("날짜/시간으로 예약 존재 여부 조회(예약 있을 때)")
     void findByDateTimeTest() {
         //given
+        Theme theme = new Theme(DUMMY_ID, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        Theme savedTheme = themeRepository.save(theme);
+
+        Reservation reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", savedTheme.getId());
         reservationRepository.save(reservation);
 
         //when
@@ -117,6 +119,10 @@ class ReservationRepositoryTest {
     void deleteReservation() {
 
         //given
+        Theme theme = new Theme(DUMMY_ID, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        Theme savedTheme = themeRepository.save(theme);
+
+        Reservation reservation = new Reservation(DUMMY_ID, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", savedTheme.getId());
         Reservation created = reservationRepository.save(reservation);
 
         //when

--- a/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
@@ -34,7 +34,7 @@ class ReservationRepositoryTest {
     @BeforeEach
     void setUp() {
         Theme theme = new Theme(null, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
-        themeRepository.create(theme);
+        themeRepository.save(theme);
 
         this.reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", 1L);
         this.reservationDuplicated = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name2", 1L);
@@ -43,14 +43,14 @@ class ReservationRepositoryTest {
     @Test
     @DisplayName("예약 삽입")
     void createReservationTest() {
-        Reservation created = reservationRepository.create(reservation);
+        Reservation created = reservationRepository.save(reservation);
         assertThat(reservationDataEquals(created, reservation)).isTrue();
     }
 
     @Test
     @DisplayName("예약 ID로 조회")
     void findByIdTest() {
-        Reservation created = reservationRepository.create(reservation);
+        Reservation created = reservationRepository.save(reservation);
         Reservation result = reservationRepository.findById(created.getId());
         assertThat(result).isEqualTo(created);
     }
@@ -58,32 +58,32 @@ class ReservationRepositoryTest {
     @Test
     @DisplayName("날짜/시간으로 예약 존재 여부 조회(예약 있을 때)")
     void findByDateTimeTest() {
-        reservationRepository.create(reservation);
-        Boolean result = reservationRepository.findByDateTime(reservation.getDate(), reservation.getTime());
+        reservationRepository.save(reservation);
+        Boolean result = reservationRepository.findByDateAndTime(reservation.getDate(), reservation.getTime());
         assertThat(result).isEqualTo(true);
     }
 
     @Test
     @DisplayName("날짜/시간으로 예약 존재 여부 조회(예약 없을 때")
     void findByDateTimeEmptyTest() {
-        Boolean result = reservationRepository.findByDateTime(LocalDate.parse("2022-08-14"), LocalTime.parse("13:00"));
+        Boolean result = reservationRepository.findByDateAndTime(LocalDate.parse("2022-08-14"), LocalTime.parse("13:00"));
         assertThat(result).isEqualTo(false);
     }
 
     @Test
     @DisplayName("이미 예약이 존재하는 시간에 예약 생성 시도할 때 예외 발생")
     void duplicateTimeReservationThrowException() {
-        reservationRepository.create(reservation);
+        reservationRepository.save(reservation);
         Assertions.assertThatThrownBy(
-                () -> reservationRepository.create(reservationDuplicated)
+                () -> reservationRepository.save(reservationDuplicated)
         ).isInstanceOf(ReservationException.class);
     }
 
     @Test
     @DisplayName("예약 삭제")
     void deleteReservation() {
-        Reservation created = reservationRepository.create(reservation);
-        Boolean result = reservationRepository.delete(created.getId());
+        Reservation created = reservationRepository.save(reservation);
+        Boolean result = reservationRepository.deleteById(created.getId());
         assertThat(result).isEqualTo(true);
 
         assertThatThrownBy(

--- a/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 import static nextstep.reservation.exception.ReservationExceptionCode.NO_SUCH_RESERVATION;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,15 +60,15 @@ class ReservationRepositoryTest {
     @DisplayName("날짜/시간으로 예약 존재 여부 조회(예약 있을 때)")
     void findByDateTimeTest() {
         reservationRepository.save(reservation);
-        Boolean result = reservationRepository.findByDateAndTime(reservation.getDate(), reservation.getTime());
-        assertThat(result).isEqualTo(true);
+        List<Reservation> result = reservationRepository.findByDateAndTime(reservation.getDate(), reservation.getTime());
+        assertThat(reservationDataEquals(reservation, result.get(0))).isTrue();
     }
 
     @Test
     @DisplayName("날짜/시간으로 예약 존재 여부 조회(예약 없을 때")
     void findByDateTimeEmptyTest() {
-        Boolean result = reservationRepository.findByDateAndTime(LocalDate.parse("2022-08-14"), LocalTime.parse("13:00"));
-        assertThat(result).isEqualTo(false);
+        List<Reservation> result = reservationRepository.findByDateAndTime(LocalDate.parse("2022-08-14"), LocalTime.parse("13:00"));
+        assertThat(result).isEqualTo(List.of());
     }
 
     @Test
@@ -83,8 +84,8 @@ class ReservationRepositoryTest {
     @DisplayName("예약 삭제")
     void deleteReservation() {
         Reservation created = reservationRepository.save(reservation);
-        Boolean result = reservationRepository.deleteById(created.getId());
-        assertThat(result).isEqualTo(true);
+        int result = reservationRepository.deleteById(created.getId());
+        assertThat(result).isEqualTo(1);
 
         assertThatThrownBy(
                 () -> reservationRepository.findById(created.getId()))

--- a/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
@@ -5,12 +5,12 @@ import nextstep.reservation.entity.Theme;
 import nextstep.reservation.exception.ReservationException;
 import nextstep.reservation.repository.ReservationRepository;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 @SpringBootTest
+@Transactional
 class ReservationRepositoryTest {
     @Autowired
     private ReservationRepository reservationRepository;
@@ -32,11 +33,6 @@ class ReservationRepositoryTest {
         Theme theme = new Theme("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
         this.reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", theme);
         this.reservationDuplicated = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name2", theme);
-    }
-
-    @AfterEach
-    void tearDown() {
-        reservationRepository.clear();
     }
 
     @Test

--- a/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
@@ -2,7 +2,6 @@ package nextstep.reservation;
 
 import nextstep.reservation.entity.Reservation;
 import nextstep.reservation.entity.Theme;
-import nextstep.reservation.exception.ReservationException;
 import nextstep.reservation.repository.ReservationRepository;
 import nextstep.reservation.repository.ThemeRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,9 +16,7 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
-import static nextstep.reservation.exception.ReservationExceptionCode.NO_SUCH_RESERVATION;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 @SpringBootTest
@@ -77,10 +74,8 @@ class ReservationRepositoryTest {
         int result = reservationRepository.deleteById(created.getId());
         assertThat(result).isEqualTo(1);
 
-        assertThatThrownBy(
-                () -> reservationRepository.findById(created.getId()))
-                .isInstanceOf(ReservationException.class)
-                .hasMessage(NO_SUCH_RESERVATION.getMessage());
+        Optional<Reservation> deletedReservationOptional = reservationRepository.findById(created.getId());
+        assertThat(deletedReservationOptional.isPresent()).isFalse();
     }
 
     private boolean reservationDataEquals(Reservation a, Reservation b) {

--- a/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
@@ -2,7 +2,7 @@ package nextstep.reservation;
 
 import nextstep.reservation.entity.Reservation;
 import nextstep.reservation.entity.Theme;
-import nextstep.reservation.exception.CreateReservationException;
+import nextstep.reservation.exception.ReservationException;
 import nextstep.reservation.repository.ReservationRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
@@ -73,7 +73,7 @@ class ReservationRepositoryTest {
         reservationRepository.create(reservation);
         Assertions.assertThatThrownBy(
                 () -> reservationRepository.create(reservationDuplicated)
-        ).isInstanceOf(CreateReservationException.class);
+        ).isInstanceOf(ReservationException.class);
     }
 
     @Test

--- a/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
@@ -1,89 +1,94 @@
-//package nextstep.reservation;
-//
-//import nextstep.reservation.entity.Reservation;
-//import nextstep.reservation.entity.Theme;
-//import nextstep.reservation.exception.ReservationException;
-//import nextstep.reservation.repository.ReservationRepository;
-//import org.assertj.core.api.Assertions;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.context.SpringBootTest;
-//import org.springframework.transaction.annotation.Transactional;
-//
-//import java.time.LocalDate;
-//import java.time.LocalTime;
-//
-//import static nextstep.reservation.exception.ReservationExceptionCode.NO_SUCH_RESERVATION;
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.assertj.core.api.Assertions.assertThatThrownBy;
-//
-//
-//@SpringBootTest
-//@Transactional
-//class ReservationRepositoryTest {
-//    @Autowired
-//    private ReservationRepository reservationRepository;
-//    private Reservation reservation;
-//    private Reservation reservationDuplicated;
-//
-//    @BeforeEach
-//    void setUp() {
-//        Theme theme = new Theme("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
-//        this.reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", theme);
-//        this.reservationDuplicated = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name2", theme);
-//    }
-//
-//    @Test
-//    @DisplayName("예약 삽입")
-//    void createReservationTest() {
-//        Reservation result = reservationRepository.create(reservation);
-//        assertThat(result).isEqualTo(reservation);
-//    }
-//
-//    @Test
-//    @DisplayName("예약 ID로 조회")
-//    void findByIdTest() {
-//        Reservation created = reservationRepository.create(reservation);
-//        Reservation result = reservationRepository.findById(created.getId());
-//        assertThat(result).isEqualTo(created);
-//    }
-//
-//    @Test
-//    @DisplayName("날짜/시간으로 예약 존재 여부 조회(예약 있을 때)")
-//    void findByDateTimeTest() {
-//        reservationRepository.create(reservation);
-//        Boolean result = reservationRepository.findByDateTime(reservation.getDate(), reservation.getTime());
-//        assertThat(result).isEqualTo(true);
-//    }
-//
-//    @Test
-//    @DisplayName("날짜/시간으로 예약 존재 여부 조회(예약 없을 때")
-//    void findByDateTimeEmptyTest() {
-//        Boolean result = reservationRepository.findByDateTime(LocalDate.parse("2022-08-14"), LocalTime.parse("13:00"));
-//        assertThat(result).isEqualTo(false);
-//    }
-//
-//    @Test
-//    @DisplayName("이미 예약이 존재하는 시간에 예약 생성 시도할 때 예외 발생")
-//    void duplicateTimeReservationThrowException() {
-//        reservationRepository.create(reservation);
-//        Assertions.assertThatThrownBy(
-//                () -> reservationRepository.create(reservationDuplicated)
-//        ).isInstanceOf(ReservationException.class);
-//    }
-//
-//    @Test
-//    @DisplayName("예약 삭제")
-//    void deleteReservation() {
-//        Reservation created = reservationRepository.create(reservation);
-//        Boolean result = reservationRepository.delete(created.getId());
-//        assertThat(result).isEqualTo(true);
-//
-//        assertThatThrownBy(
-//                () -> reservationRepository.findById(created.getId()))
-//                .isInstanceOf(ReservationException.class)
-//                .hasMessage(NO_SUCH_RESERVATION.getMessage());
-//    }
-//}
+package nextstep.reservation;
+
+import nextstep.reservation.entity.Reservation;
+import nextstep.reservation.entity.Theme;
+import nextstep.reservation.exception.ReservationException;
+import nextstep.reservation.repository.ReservationRepository;
+import nextstep.reservation.repository.ThemeRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static nextstep.reservation.exception.ReservationExceptionCode.NO_SUCH_RESERVATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+@SpringBootTest
+@Transactional
+class ReservationRepositoryTest {
+    @Autowired
+    private ReservationRepository reservationRepository;
+    @Autowired
+    private ThemeRepository themeRepository;
+    private Reservation reservation;
+    private Reservation reservationDuplicated;
+
+    @BeforeEach
+    void setUp() {
+        Theme theme = new Theme(null, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        themeRepository.create(theme);
+
+        this.reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", 1L);
+        this.reservationDuplicated = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name2", 1L);
+    }
+
+    @Test
+    @DisplayName("예약 삽입")
+    void createReservationTest() {
+        Reservation result = reservationRepository.create(reservation);
+        assertThat(result).isEqualTo(reservation);
+    }
+
+    @Test
+    @DisplayName("예약 ID로 조회")
+    void findByIdTest() {
+        Reservation created = reservationRepository.create(reservation);
+        Reservation result = reservationRepository.findById(created.getId());
+        assertThat(result).isEqualTo(created);
+    }
+
+    @Test
+    @DisplayName("날짜/시간으로 예약 존재 여부 조회(예약 있을 때)")
+    void findByDateTimeTest() {
+        reservationRepository.create(reservation);
+        Boolean result = reservationRepository.findByDateTime(reservation.getDate(), reservation.getTime());
+        assertThat(result).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("날짜/시간으로 예약 존재 여부 조회(예약 없을 때")
+    void findByDateTimeEmptyTest() {
+        Boolean result = reservationRepository.findByDateTime(LocalDate.parse("2022-08-14"), LocalTime.parse("13:00"));
+        assertThat(result).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("이미 예약이 존재하는 시간에 예약 생성 시도할 때 예외 발생")
+    void duplicateTimeReservationThrowException() {
+        reservationRepository.create(reservation);
+        Assertions.assertThatThrownBy(
+                () -> reservationRepository.create(reservationDuplicated)
+        ).isInstanceOf(ReservationException.class);
+    }
+
+    @Test
+    @DisplayName("예약 삭제")
+    void deleteReservation() {
+        Reservation created = reservationRepository.create(reservation);
+        Boolean result = reservationRepository.delete(created.getId());
+        assertThat(result).isEqualTo(true);
+
+        assertThatThrownBy(
+                () -> reservationRepository.findById(created.getId()))
+                .isInstanceOf(ReservationException.class)
+                .hasMessage(NO_SUCH_RESERVATION.getMessage());
+    }
+}

--- a/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
@@ -1,89 +1,89 @@
-package nextstep.reservation;
-
-import nextstep.reservation.entity.Reservation;
-import nextstep.reservation.entity.Theme;
-import nextstep.reservation.exception.ReservationException;
-import nextstep.reservation.repository.ReservationRepository;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
-
-import static nextstep.reservation.exception.ReservationExceptionCode.NO_SUCH_RESERVATION;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-
-@SpringBootTest
-@Transactional
-class ReservationRepositoryTest {
-    @Autowired
-    private ReservationRepository reservationRepository;
-    private Reservation reservation;
-    private Reservation reservationDuplicated;
-
-    @BeforeEach
-    void setUp() {
-        Theme theme = new Theme("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
-        this.reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", theme);
-        this.reservationDuplicated = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name2", theme);
-    }
-
-    @Test
-    @DisplayName("예약 삽입")
-    void createReservationTest() {
-        Reservation result = reservationRepository.create(reservation);
-        assertThat(result).isEqualTo(reservation);
-    }
-
-    @Test
-    @DisplayName("예약 ID로 조회")
-    void findByIdTest() {
-        Reservation created = reservationRepository.create(reservation);
-        Reservation result = reservationRepository.findById(created.getId());
-        assertThat(result).isEqualTo(created);
-    }
-
-    @Test
-    @DisplayName("날짜/시간으로 예약 존재 여부 조회(예약 있을 때)")
-    void findByDateTimeTest() {
-        reservationRepository.create(reservation);
-        Boolean result = reservationRepository.findByDateTime(reservation.getDate(), reservation.getTime());
-        assertThat(result).isEqualTo(true);
-    }
-
-    @Test
-    @DisplayName("날짜/시간으로 예약 존재 여부 조회(예약 없을 때")
-    void findByDateTimeEmptyTest() {
-        Boolean result = reservationRepository.findByDateTime(LocalDate.parse("2022-08-14"), LocalTime.parse("13:00"));
-        assertThat(result).isEqualTo(false);
-    }
-
-    @Test
-    @DisplayName("이미 예약이 존재하는 시간에 예약 생성 시도할 때 예외 발생")
-    void duplicateTimeReservationThrowException() {
-        reservationRepository.create(reservation);
-        Assertions.assertThatThrownBy(
-                () -> reservationRepository.create(reservationDuplicated)
-        ).isInstanceOf(ReservationException.class);
-    }
-
-    @Test
-    @DisplayName("예약 삭제")
-    void deleteReservation() {
-        Reservation created = reservationRepository.create(reservation);
-        Boolean result = reservationRepository.delete(created.getId());
-        assertThat(result).isEqualTo(true);
-
-        assertThatThrownBy(
-                () -> reservationRepository.findById(created.getId()))
-                .isInstanceOf(ReservationException.class)
-                .hasMessage(NO_SUCH_RESERVATION.getMessage());
-    }
-}
+//package nextstep.reservation;
+//
+//import nextstep.reservation.entity.Reservation;
+//import nextstep.reservation.entity.Theme;
+//import nextstep.reservation.exception.ReservationException;
+//import nextstep.reservation.repository.ReservationRepository;
+//import org.assertj.core.api.Assertions;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//import java.time.LocalDate;
+//import java.time.LocalTime;
+//
+//import static nextstep.reservation.exception.ReservationExceptionCode.NO_SUCH_RESERVATION;
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.assertj.core.api.Assertions.assertThatThrownBy;
+//
+//
+//@SpringBootTest
+//@Transactional
+//class ReservationRepositoryTest {
+//    @Autowired
+//    private ReservationRepository reservationRepository;
+//    private Reservation reservation;
+//    private Reservation reservationDuplicated;
+//
+//    @BeforeEach
+//    void setUp() {
+//        Theme theme = new Theme("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+//        this.reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", theme);
+//        this.reservationDuplicated = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name2", theme);
+//    }
+//
+//    @Test
+//    @DisplayName("예약 삽입")
+//    void createReservationTest() {
+//        Reservation result = reservationRepository.create(reservation);
+//        assertThat(result).isEqualTo(reservation);
+//    }
+//
+//    @Test
+//    @DisplayName("예약 ID로 조회")
+//    void findByIdTest() {
+//        Reservation created = reservationRepository.create(reservation);
+//        Reservation result = reservationRepository.findById(created.getId());
+//        assertThat(result).isEqualTo(created);
+//    }
+//
+//    @Test
+//    @DisplayName("날짜/시간으로 예약 존재 여부 조회(예약 있을 때)")
+//    void findByDateTimeTest() {
+//        reservationRepository.create(reservation);
+//        Boolean result = reservationRepository.findByDateTime(reservation.getDate(), reservation.getTime());
+//        assertThat(result).isEqualTo(true);
+//    }
+//
+//    @Test
+//    @DisplayName("날짜/시간으로 예약 존재 여부 조회(예약 없을 때")
+//    void findByDateTimeEmptyTest() {
+//        Boolean result = reservationRepository.findByDateTime(LocalDate.parse("2022-08-14"), LocalTime.parse("13:00"));
+//        assertThat(result).isEqualTo(false);
+//    }
+//
+//    @Test
+//    @DisplayName("이미 예약이 존재하는 시간에 예약 생성 시도할 때 예외 발생")
+//    void duplicateTimeReservationThrowException() {
+//        reservationRepository.create(reservation);
+//        Assertions.assertThatThrownBy(
+//                () -> reservationRepository.create(reservationDuplicated)
+//        ).isInstanceOf(ReservationException.class);
+//    }
+//
+//    @Test
+//    @DisplayName("예약 삭제")
+//    void deleteReservation() {
+//        Reservation created = reservationRepository.create(reservation);
+//        Boolean result = reservationRepository.delete(created.getId());
+//        assertThat(result).isEqualTo(true);
+//
+//        assertThatThrownBy(
+//                () -> reservationRepository.findById(created.getId()))
+//                .isInstanceOf(ReservationException.class)
+//                .hasMessage(NO_SUCH_RESERVATION.getMessage());
+//    }
+//}

--- a/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ReservationRepositoryTest.java
@@ -5,7 +5,6 @@ import nextstep.reservation.entity.Theme;
 import nextstep.reservation.exception.ReservationException;
 import nextstep.reservation.repository.ReservationRepository;
 import nextstep.reservation.repository.ThemeRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 import static nextstep.reservation.exception.ReservationExceptionCode.NO_SUCH_RESERVATION;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,7 +30,6 @@ class ReservationRepositoryTest {
     @Autowired
     private ThemeRepository themeRepository;
     private Reservation reservation;
-    private Reservation reservationDuplicated;
 
     @BeforeEach
     void setUp() {
@@ -38,7 +37,6 @@ class ReservationRepositoryTest {
         themeRepository.save(theme);
 
         this.reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", 1L);
-        this.reservationDuplicated = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name2", 1L);
     }
 
     @Test
@@ -52,8 +50,9 @@ class ReservationRepositoryTest {
     @DisplayName("예약 ID로 조회")
     void findByIdTest() {
         Reservation created = reservationRepository.save(reservation);
-        Reservation result = reservationRepository.findById(created.getId());
-        assertThat(result).isEqualTo(created);
+        Optional<Reservation> result = reservationRepository.findById(created.getId());
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get()).isEqualTo(created);
     }
 
     @Test
@@ -69,15 +68,6 @@ class ReservationRepositoryTest {
     void findByDateTimeEmptyTest() {
         List<Reservation> result = reservationRepository.findByDateAndTime(LocalDate.parse("2022-08-14"), LocalTime.parse("13:00"));
         assertThat(result).isEqualTo(List.of());
-    }
-
-    @Test
-    @DisplayName("이미 예약이 존재하는 시간에 예약 생성 시도할 때 예외 발생")
-    void duplicateTimeReservationThrowException() {
-        reservationRepository.save(reservation);
-        Assertions.assertThatThrownBy(
-                () -> reservationRepository.save(reservationDuplicated)
-        ).isInstanceOf(ReservationException.class);
     }
 
     @Test

--- a/src/test/java/nextstep/reservation/ReservationServiceTest.java
+++ b/src/test/java/nextstep/reservation/ReservationServiceTest.java
@@ -1,6 +1,6 @@
 package nextstep.reservation;
 
-import nextstep.reservation.entity.Reservation;
+import nextstep.reservation.dto.ReservationRequest;
 import nextstep.reservation.entity.Theme;
 import nextstep.reservation.exception.ReservationException;
 import nextstep.reservation.repository.ThemeRepository;
@@ -26,22 +26,22 @@ class ReservationServiceTest {
     private ReservationService reservationService;
     @Autowired
     private ThemeRepository themeRepository;
-    private Reservation reservation;
+    private ReservationRequest reservation;
 
     @BeforeEach
     void setUp() {
         Theme theme = new Theme(null, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
-        themeRepository.save(theme);
+        Theme savedTheme = themeRepository.save(theme);
 
-        this.reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", 1L);
+        this.reservation = new ReservationRequest(LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", savedTheme.getId());
     }
 
     @Test
     @DisplayName("이미 예약이 존재하는 시간에 예약 생성 시도할 때 예외 발생")
     void duplicate_time_Reservation_Exception() {
         //given
-        Reservation reservationDuplicated = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name2", 1L);
-        reservationService.registerReservation(reservation);
+        ReservationRequest reservationDuplicated = new ReservationRequest(LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name2", reservation.getThemeId());
+        reservationService.registerReservation(reservationDuplicated);
 
         //when
         //then

--- a/src/test/java/nextstep/reservation/ReservationServiceTest.java
+++ b/src/test/java/nextstep/reservation/ReservationServiceTest.java
@@ -1,0 +1,63 @@
+package nextstep.reservation;
+
+import nextstep.reservation.entity.Reservation;
+import nextstep.reservation.entity.Theme;
+import nextstep.reservation.exception.ReservationException;
+import nextstep.reservation.repository.ThemeRepository;
+import nextstep.reservation.service.ReservationService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static nextstep.reservation.exception.ReservationExceptionCode.DUPLICATE_TIME_RESERVATION;
+import static nextstep.reservation.exception.ReservationExceptionCode.NO_SUCH_RESERVATION;
+
+@SpringBootTest
+@Transactional
+class ReservationServiceTest {
+    @Autowired
+    private ReservationService reservationService;
+    @Autowired
+    private ThemeRepository themeRepository;
+    private Reservation reservation;
+
+    @BeforeEach
+    void setUp() {
+        Theme theme = new Theme(null, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        themeRepository.save(theme);
+
+        this.reservation = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", 1L);
+    }
+
+    @Test
+    @DisplayName("이미 예약이 존재하는 시간에 예약 생성 시도할 때 예외 발생")
+    void duplicate_time_Reservation_Exception() {
+        //given
+        Reservation reservationDuplicated = new Reservation(null, LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name2", 1L);
+        reservationService.registerReservation(reservation);
+
+        //when
+        //then
+        Assertions.assertThatThrownBy(
+                () -> reservationService.registerReservation(reservationDuplicated)
+        ).isInstanceOf(ReservationException.class).hasMessage(DUPLICATE_TIME_RESERVATION.getMessage());
+    }
+
+    @Test
+    @DisplayName("생성되지 않은 예약의 ID를 입력할 때 예약 발생")
+    void find_have_never_registered_Reservation_by_id_Exception() {
+        //given
+        //when
+        //then
+        Assertions.assertThatThrownBy(
+                () -> reservationService.findById(1L)
+        ).isInstanceOf(ReservationException.class).hasMessage(NO_SUCH_RESERVATION.getMessage());
+    }
+}

--- a/src/test/java/nextstep/reservation/ReservationServiceTest.java
+++ b/src/test/java/nextstep/reservation/ReservationServiceTest.java
@@ -7,7 +7,6 @@ import nextstep.reservation.exception.RoomEscapeException;
 import nextstep.reservation.service.ReservationService;
 import nextstep.reservation.service.ThemeService;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,23 +26,18 @@ class ReservationServiceTest {
     private ReservationService reservationService;
     @Autowired
     private ThemeService themeService;
-    private ReservationRequest reservation;
-
-    @BeforeEach
-    void setUp() {
-        ThemeRequest themeRequest = new ThemeRequest("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
-
-        ThemeResponse themeResponse = themeService.registerTheme(themeRequest);
-
-        this.reservation = new ReservationRequest(LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", themeResponse.getId());
-    }
 
     @Test
     @DisplayName("이미 예약이 존재하는 시간에 예약 생성 시도할 때 예외 발생한다.")
     void duplicate_time_Reservation_Exception() {
         //given
+        ThemeRequest themeRequest = new ThemeRequest("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
+        ThemeResponse themeResponse = themeService.registerTheme(themeRequest);
+
+        ReservationRequest reservation = new ReservationRequest(LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", themeResponse.getId());
+        reservationService.registerReservation(reservation);
+
         ReservationRequest reservationDuplicated = new ReservationRequest(LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name2", reservation.getThemeId());
-        reservationService.registerReservation(reservationDuplicated);
 
         //when
         //then

--- a/src/test/java/nextstep/reservation/ReservationServiceTest.java
+++ b/src/test/java/nextstep/reservation/ReservationServiceTest.java
@@ -2,7 +2,7 @@ package nextstep.reservation;
 
 import nextstep.reservation.dto.ReservationRequest;
 import nextstep.reservation.entity.Theme;
-import nextstep.reservation.exception.ReservationException;
+import nextstep.reservation.exception.RoomEscapeException;
 import nextstep.reservation.repository.ThemeRepository;
 import nextstep.reservation.service.ReservationService;
 import org.assertj.core.api.Assertions;
@@ -16,8 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-import static nextstep.reservation.exception.ReservationExceptionCode.DUPLICATE_TIME_RESERVATION;
-import static nextstep.reservation.exception.ReservationExceptionCode.NO_SUCH_RESERVATION;
+import static nextstep.reservation.exception.RoomEscapeExceptionCode.DUPLICATE_TIME_RESERVATION;
+import static nextstep.reservation.exception.RoomEscapeExceptionCode.NO_SUCH_RESERVATION;
 
 @SpringBootTest
 @Transactional
@@ -47,7 +47,7 @@ class ReservationServiceTest {
         //then
         Assertions.assertThatThrownBy(
                 () -> reservationService.registerReservation(reservationDuplicated)
-        ).isInstanceOf(ReservationException.class).hasMessage(DUPLICATE_TIME_RESERVATION.getMessage());
+        ).isInstanceOf(RoomEscapeException.class).hasMessage(DUPLICATE_TIME_RESERVATION.getMessage());
     }
 
     @Test
@@ -58,6 +58,6 @@ class ReservationServiceTest {
         //then
         Assertions.assertThatThrownBy(
                 () -> reservationService.findById(1L)
-        ).isInstanceOf(ReservationException.class).hasMessage(NO_SUCH_RESERVATION.getMessage());
+        ).isInstanceOf(RoomEscapeException.class).hasMessage(NO_SUCH_RESERVATION.getMessage());
     }
 }

--- a/src/test/java/nextstep/reservation/ReservationServiceTest.java
+++ b/src/test/java/nextstep/reservation/ReservationServiceTest.java
@@ -1,10 +1,11 @@
 package nextstep.reservation;
 
 import nextstep.reservation.dto.ReservationRequest;
-import nextstep.reservation.entity.Theme;
+import nextstep.reservation.dto.ThemeRequest;
+import nextstep.reservation.dto.ThemeResponse;
 import nextstep.reservation.exception.RoomEscapeException;
-import nextstep.reservation.repository.ThemeRepository;
 import nextstep.reservation.service.ReservationService;
+import nextstep.reservation.service.ThemeService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,19 +26,20 @@ class ReservationServiceTest {
     @Autowired
     private ReservationService reservationService;
     @Autowired
-    private ThemeRepository themeRepository;
+    private ThemeService themeService;
     private ReservationRequest reservation;
 
     @BeforeEach
     void setUp() {
-        Theme theme = new Theme(null, "워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
-        Theme savedTheme = themeRepository.save(theme);
+        ThemeRequest themeRequest = new ThemeRequest("워너고홈", "병맛 어드벤처 회사 코믹물", 29000);
 
-        this.reservation = new ReservationRequest(LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", savedTheme.getId());
+        ThemeResponse themeResponse = themeService.registerTheme(themeRequest);
+
+        this.reservation = new ReservationRequest(LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name", themeResponse.getId());
     }
 
     @Test
-    @DisplayName("이미 예약이 존재하는 시간에 예약 생성 시도할 때 예외 발생")
+    @DisplayName("이미 예약이 존재하는 시간에 예약 생성 시도할 때 예외 발생한다.")
     void duplicate_time_Reservation_Exception() {
         //given
         ReservationRequest reservationDuplicated = new ReservationRequest(LocalDate.parse("2022-08-12"), LocalTime.parse("13:00"), "name2", reservation.getThemeId());
@@ -51,7 +53,7 @@ class ReservationServiceTest {
     }
 
     @Test
-    @DisplayName("생성되지 않은 예약의 ID를 입력할 때 예약 발생")
+    @DisplayName("생성되지 않은 예약의 ID로 예약 조회할 때 에외 발생한다.")
     void find_have_never_registered_Reservation_by_id_Exception() {
         //given
         //when

--- a/src/test/java/nextstep/reservation/ThemeControllerTest.java
+++ b/src/test/java/nextstep/reservation/ThemeControllerTest.java
@@ -1,7 +1,8 @@
 package nextstep.reservation;
 
 import io.restassured.RestAssured;
-import nextstep.reservation.entity.Theme;
+import nextstep.reservation.dto.ThemeRequest;
+import nextstep.reservation.dto.ThemeResponse;
 import nextstep.reservation.service.ThemeService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
@@ -23,12 +24,12 @@ public class ThemeControllerTest {
     int port;
     @Autowired
     private ThemeService themeService;
-    private Theme theme;
+    private ThemeRequest themeRequest;
 
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
-        this.theme = new Theme(null, "호러", "매우 무서운", 24000);
+        this.themeRequest = new ThemeRequest("호러", "매우 무서운", 24000);
     }
 
     @AfterEach
@@ -41,7 +42,7 @@ public class ThemeControllerTest {
     void create() {
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(theme)
+                .body(themeRequest)
                 .when().post("/themes")
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value());
@@ -51,28 +52,28 @@ public class ThemeControllerTest {
     @DisplayName("전체 테마 조회")
     void findAll() {
         //given
-        themeService.create(theme);
-        Theme theme2 = new Theme(null, "ad", "cd", 2000);
-        themeService.create(theme2);
+        themeService.registerTheme(themeRequest);
+        ThemeRequest themeRequest2 = new ThemeRequest("ad", "cd", 2000);
+        themeService.registerTheme(themeRequest2);
 
         //when
-        List<Theme> themeList = RestAssured.given().log().all()
+        List<ThemeResponse> themeList = RestAssured.given().log().all()
                 .when().get("/themes")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract().response().jsonPath()
-                .getList("", Theme.class);
+                .getList("", ThemeResponse.class);
 
         //then
-        Assertions.assertThat(themeTestEquals(theme, themeList.get(0))).isTrue();
-        Assertions.assertThat(themeTestEquals(theme2, themeList.get(1))).isTrue();
+        Assertions.assertThat(themeTestEquals(themeRequest, themeList.get(0))).isTrue();
+        Assertions.assertThat(themeTestEquals(themeRequest2, themeList.get(1))).isTrue();
     }
 
     @Test
     @DisplayName("테마 id로 삭제")
     void deleteById() {
         //given
-        Theme created = themeService.create(theme);
+        ThemeResponse created = themeService.registerTheme(themeRequest);
 
         //when
         RestAssured.given().log().all()
@@ -81,7 +82,7 @@ public class ThemeControllerTest {
                 .statusCode(HttpStatus.NO_CONTENT.value());
     }
 
-    private boolean themeTestEquals(Theme a, Theme b) {
+    private boolean themeTestEquals(ThemeRequest a, ThemeResponse b) {
         return a.getName().equals(b.getName()) &&
                 a.getDesc().equals(b.getDesc()) &&
                 a.getPrice().equals(b.getPrice());

--- a/src/test/java/nextstep/reservation/ThemeControllerTest.java
+++ b/src/test/java/nextstep/reservation/ThemeControllerTest.java
@@ -1,0 +1,89 @@
+package nextstep.reservation;
+
+import io.restassured.RestAssured;
+import nextstep.reservation.entity.Theme;
+import nextstep.reservation.service.ThemeService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ThemeControllerTest {
+    @LocalServerPort
+    int port;
+    @Autowired
+    private ThemeService themeService;
+    private Theme theme;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        this.theme = new Theme(null, "호러", "매우 무서운", 24000);
+    }
+
+    @AfterEach
+    void tearDown() {
+        themeService.clear();
+    }
+
+    @Test
+    @DisplayName("생성")
+    void create() {
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(theme)
+                .when().post("/themes")
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    @DisplayName("전체 테마 조회")
+    void findAll() {
+        //given
+        themeService.create(theme);
+        Theme theme2 = new Theme(null, "ad", "cd", 2000);
+        themeService.create(theme2);
+
+        //when
+        List<Theme> themeList = RestAssured.given().log().all()
+                .when().get("/themes")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract().response().jsonPath()
+                .getList("", Theme.class);
+
+        //then
+        Assertions.assertThat(themeTestEquals(theme, themeList.get(0))).isTrue();
+        Assertions.assertThat(themeTestEquals(theme2, themeList.get(1))).isTrue();
+    }
+
+    @Test
+    @DisplayName("테마 id로 삭제")
+    void deleteById() {
+        //given
+        Theme created = themeService.create(theme);
+
+        //when
+        RestAssured.given().log().all()
+                .when().delete("/themes/" + created.getId())
+                .then().log().all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    private boolean themeTestEquals(Theme a, Theme b) {
+        return a.getName().equals(b.getName()) &&
+                a.getDesc().equals(b.getDesc()) &&
+                a.getPrice().equals(b.getPrice());
+    }
+}

--- a/src/test/java/nextstep/reservation/ThemeControllerTest.java
+++ b/src/test/java/nextstep/reservation/ThemeControllerTest.java
@@ -6,7 +6,6 @@ import nextstep.reservation.dto.ThemeResponse;
 import nextstep.reservation.service.ThemeService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,13 +23,6 @@ public class ThemeControllerTest {
     int port;
     @Autowired
     private ThemeService themeService;
-    private ThemeRequest themeRequest;
-
-    @BeforeEach
-    void setUp() {
-        RestAssured.port = port;
-        this.themeRequest = new ThemeRequest("호러", "매우 무서운", 24000);
-    }
 
     @AfterEach
     void tearDown() {
@@ -40,6 +32,12 @@ public class ThemeControllerTest {
     @Test
     @DisplayName("테마 생성 성공시 201 반환한다.")
     void create() {
+        //given
+        RestAssured.port = port;
+        ThemeRequest themeRequest = new ThemeRequest("호러", "매우 무서운", 24000);
+
+        //when
+        //then
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(themeRequest)
@@ -51,10 +49,17 @@ public class ThemeControllerTest {
     @Test
     @DisplayName("전체 테마 조회시 body에 JSON 배열 형태로 반환된다.")
     void findAll() {
+        //given
+        RestAssured.port = port;
+
+        ThemeRequest themeRequest = new ThemeRequest("호러", "매우 무서운", 24000);
         themeService.registerTheme(themeRequest);
+
         ThemeRequest themeRequest2 = new ThemeRequest("ad", "cd", 2000);
         themeService.registerTheme(themeRequest2);
 
+        //when
+        //then
         List<ThemeResponse> themeList = RestAssured.given().log().all()
                 .when().get("/themes")
                 .then().log().all()
@@ -69,8 +74,14 @@ public class ThemeControllerTest {
     @Test
     @DisplayName("테마 id로 삭제시 204 반환된다.")
     void deleteById() {
+        //given
+        RestAssured.port = port;
+
+        ThemeRequest themeRequest = new ThemeRequest("호러", "매우 무서운", 24000);
         ThemeResponse created = themeService.registerTheme(themeRequest);
 
+        //when
+        //then
         RestAssured.given().log().all()
                 .when().delete("/themes/" + created.getId())
                 .then().log().all()

--- a/src/test/java/nextstep/reservation/ThemeControllerTest.java
+++ b/src/test/java/nextstep/reservation/ThemeControllerTest.java
@@ -38,7 +38,7 @@ public class ThemeControllerTest {
     }
 
     @Test
-    @DisplayName("생성")
+    @DisplayName("테마 생성 성공시 201 반환한다.")
     void create() {
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -49,14 +49,12 @@ public class ThemeControllerTest {
     }
 
     @Test
-    @DisplayName("전체 테마 조회")
+    @DisplayName("전체 테마 조회시 body에 JSON 배열 형태로 반환된다.")
     void findAll() {
-        //given
         themeService.registerTheme(themeRequest);
         ThemeRequest themeRequest2 = new ThemeRequest("ad", "cd", 2000);
         themeService.registerTheme(themeRequest2);
 
-        //when
         List<ThemeResponse> themeList = RestAssured.given().log().all()
                 .when().get("/themes")
                 .then().log().all()
@@ -64,25 +62,22 @@ public class ThemeControllerTest {
                 .extract().response().jsonPath()
                 .getList("", ThemeResponse.class);
 
-        //then
         Assertions.assertThat(themeTestEquals(themeRequest, themeList.get(0))).isTrue();
         Assertions.assertThat(themeTestEquals(themeRequest2, themeList.get(1))).isTrue();
     }
 
     @Test
-    @DisplayName("테마 id로 삭제")
+    @DisplayName("테마 id로 삭제시 204 반환된다.")
     void deleteById() {
-        //given
         ThemeResponse created = themeService.registerTheme(themeRequest);
 
-        //when
         RestAssured.given().log().all()
                 .when().delete("/themes/" + created.getId())
                 .then().log().all()
                 .statusCode(HttpStatus.NO_CONTENT.value());
     }
 
-    private boolean themeTestEquals(ThemeRequest a, ThemeResponse b) {
+    private boolean themeTestEquals(ThemeRequest a, ThemeResponse b) { //id를 제외한 Content 비교
         return a.getName().equals(b.getName()) &&
                 a.getDesc().equals(b.getDesc()) &&
                 a.getPrice().equals(b.getPrice());

--- a/src/test/java/nextstep/reservation/ThemeRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ThemeRepositoryTest.java
@@ -12,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
-import static nextstep.reservation.constant.RoomEscapeConstant.DUMMY_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
@@ -26,7 +25,7 @@ class ThemeRepositoryTest {
     @DisplayName("테마 생성")
     void create() {
         //given
-        Theme theme = new Theme(DUMMY_ID, "호러", "매우 무서운", 24000);
+        Theme theme = new Theme(null, "호러", "매우 무서운", 24000);
 
         //when
         Theme created = jdbcThemeRepository.save(theme);
@@ -39,7 +38,7 @@ class ThemeRepositoryTest {
     @DisplayName("id를 통한 조회")
     void findById() {
         //given
-        Theme theme = new Theme(DUMMY_ID, "호러", "매우 무서운", 24000);
+        Theme theme = new Theme(null, "호러", "매우 무서운", 24000);
         Theme created = jdbcThemeRepository.save(theme);
 
         //when
@@ -55,7 +54,7 @@ class ThemeRepositoryTest {
     @DisplayName("전체 조회시 리스트로 반환")
     void findAll() {
         //given
-        Theme theme = new Theme(DUMMY_ID, "호러", "매우 무서운", 24000);
+        Theme theme = new Theme(null, "호러", "매우 무서운", 24000);
         Theme created = jdbcThemeRepository.save(theme);
         Theme created2 = jdbcThemeRepository.save(theme);
 
@@ -70,7 +69,7 @@ class ThemeRepositoryTest {
     @DisplayName("id를 통한 삭제 성공")
     void deleteById() {
         //given
-        Theme theme = new Theme(DUMMY_ID, "호러", "매우 무서운", 24000);
+        Theme theme = new Theme(null, "호러", "매우 무서운", 24000);
         Theme created = jdbcThemeRepository.save(theme);
 
         //when
@@ -84,7 +83,7 @@ class ThemeRepositoryTest {
     @DisplayName("테이블 전체 삭제")
     void clear() {
         //given
-        Theme theme = new Theme(DUMMY_ID, "호러", "매우 무서운", 24000);
+        Theme theme = new Theme(null, "호러", "매우 무서운", 24000);
         Theme created = jdbcThemeRepository.save(theme);
         Theme created2 = jdbcThemeRepository.save(theme);
 

--- a/src/test/java/nextstep/reservation/ThemeRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ThemeRepositoryTest.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
+import static nextstep.reservation.constant.RoomEscapeConstant.DUMMY_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
@@ -25,7 +26,7 @@ class ThemeRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        this.theme = new Theme(null, "호러", "매우 무서운", 24000);
+        this.theme = new Theme(DUMMY_ID, "호러", "매우 무서운", 24000);
     }
 
     @Test

--- a/src/test/java/nextstep/reservation/ThemeRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ThemeRepositoryTest.java
@@ -3,7 +3,6 @@ package nextstep.reservation;
 import nextstep.reservation.entity.Theme;
 import nextstep.reservation.repository.JdbcThemeRepository;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,17 +21,12 @@ class ThemeRepositoryTest {
 
     @Autowired
     private JdbcThemeRepository jdbcThemeRepository;
-    private Theme theme;
-
-    @BeforeEach
-    void setUp() {
-        this.theme = new Theme(DUMMY_ID, "호러", "매우 무서운", 24000);
-    }
 
     @Test
     @DisplayName("테마 생성")
     void create() {
         //given
+        Theme theme = new Theme(DUMMY_ID, "호러", "매우 무서운", 24000);
 
         //when
         Theme created = jdbcThemeRepository.save(theme);
@@ -45,6 +39,7 @@ class ThemeRepositoryTest {
     @DisplayName("id를 통한 조회")
     void findById() {
         //given
+        Theme theme = new Theme(DUMMY_ID, "호러", "매우 무서운", 24000);
         Theme created = jdbcThemeRepository.save(theme);
 
         //when
@@ -60,6 +55,7 @@ class ThemeRepositoryTest {
     @DisplayName("전체 조회시 리스트로 반환")
     void findAll() {
         //given
+        Theme theme = new Theme(DUMMY_ID, "호러", "매우 무서운", 24000);
         Theme created = jdbcThemeRepository.save(theme);
         Theme created2 = jdbcThemeRepository.save(theme);
 
@@ -74,6 +70,7 @@ class ThemeRepositoryTest {
     @DisplayName("id를 통한 삭제 성공")
     void deleteById() {
         //given
+        Theme theme = new Theme(DUMMY_ID, "호러", "매우 무서운", 24000);
         Theme created = jdbcThemeRepository.save(theme);
 
         //when
@@ -87,6 +84,7 @@ class ThemeRepositoryTest {
     @DisplayName("테이블 전체 삭제")
     void clear() {
         //given
+        Theme theme = new Theme(DUMMY_ID, "호러", "매우 무서운", 24000);
         Theme created = jdbcThemeRepository.save(theme);
         Theme created2 = jdbcThemeRepository.save(theme);
 

--- a/src/test/java/nextstep/reservation/ThemeRepositoryTest.java
+++ b/src/test/java/nextstep/reservation/ThemeRepositoryTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
-class JdbcThemeRepositoryTest {
+class ThemeRepositoryTest {
 
     @Autowired
     private JdbcThemeRepository jdbcThemeRepository;
@@ -29,7 +29,7 @@ class JdbcThemeRepositoryTest {
     }
 
     @Test
-    @DisplayName("생성")
+    @DisplayName("테마 생성")
     void create() {
         //given
 
@@ -56,7 +56,7 @@ class JdbcThemeRepositoryTest {
 
 
     @Test
-    @DisplayName("전체 조회")
+    @DisplayName("전체 조회시 리스트로 반환")
     void findAll() {
         //given
         Theme created = jdbcThemeRepository.save(theme);
@@ -70,7 +70,7 @@ class JdbcThemeRepositoryTest {
     }
 
     @Test
-    @DisplayName("id를 통한 삭제")
+    @DisplayName("id를 통한 삭제 성공")
     void deleteById() {
         //given
         Theme created = jdbcThemeRepository.save(theme);
@@ -98,7 +98,7 @@ class JdbcThemeRepositoryTest {
 
     }
 
-    private boolean themeTestEquals(Theme a, Theme b) {
+    private boolean themeTestEquals(Theme a, Theme b) { //id를 제외한 Content 비교
         return a.getName().equals(b.getName()) &&
                 a.getDesc().equals(b.getDesc()) &&
                 a.getPrice().equals(b.getPrice());

--- a/src/test/java/nextstep/reservation/ThemeServiceTest.java
+++ b/src/test/java/nextstep/reservation/ThemeServiceTest.java
@@ -1,0 +1,46 @@
+package nextstep.reservation;
+
+import nextstep.reservation.dto.ReservationRequest;
+import nextstep.reservation.dto.ThemeRequest;
+import nextstep.reservation.dto.ThemeResponse;
+import nextstep.reservation.exception.RoomEscapeException;
+import nextstep.reservation.service.ReservationService;
+import nextstep.reservation.service.ThemeService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static nextstep.reservation.exception.RoomEscapeExceptionCode.RESERVATION_EXIST;
+
+@SpringBootTest
+public class ThemeServiceTest {
+    @Autowired
+    ThemeService themeService;
+    @Autowired
+    ReservationService reservationService;
+
+
+    @Test
+    @DisplayName("테마가 예약에 등록돼있으면 삭제에 실패한다.")
+    void Theme_deletion_fail_when_it_has_been_registered_in_any_Reservation() {
+        //given
+        ThemeRequest themeRequest = ThemeRequest.builder().name("호러").desc("매우무서운").price(25000).build();
+        ThemeResponse themeResponse = themeService.registerTheme(themeRequest);
+
+        ReservationRequest reservationRequest = ReservationRequest.builder().date(LocalDate.parse("2022-12-05")).time(LocalTime.parse("10:00")).name("herbi").themeId(themeResponse.getId()).build();
+        reservationService.registerReservation(reservationRequest);
+
+        //when
+        //then
+        Assertions.assertThatThrownBy(
+                        () -> themeService.deleteById(themeResponse.getId()))
+                .isInstanceOf(RoomEscapeException.class)
+                .hasMessage(RESERVATION_EXIST.getMessage());
+
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,11 +5,10 @@ spring:
       path: /h2-console
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:~/test4
+    url: jdbc:h2:mem:test
     username: sa
     password:
   sql:
     init:
-      #      mode: always # 처음 실행할때는 always
-      mode: never # 이후에는 never로 변경
+      mode: always
       schema-locations: classpath:schema.sql

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE RESERVATION
+CREATE TABLE IF NOT EXISTS RESERVATION
 (
     id          bigint not null auto_increment,
     date        date,

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,9 +1,9 @@
 CREATE TABLE IF NOT EXISTS RESERVATION
 (
     id          bigint not null auto_increment,
-    date     date,
-    time     time,
-    name        varchar(20),
+    date     date not null,
+    time     time not null,
+    name        varchar(20) not null,
     theme_id bigint not null,
     primary key (id)
     );
@@ -11,8 +11,8 @@ CREATE TABLE IF NOT EXISTS RESERVATION
 CREATE TABLE IF NOT EXISTS theme
 (
     id    bigint not null auto_increment,
-    name  varchar(20),
-    desc  varchar(255),
-    price int,
+    name  varchar(20) not null,
+    desc  varchar(255) not null,
+    price int not null,
     primary key (id)
     );

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,11 +1,18 @@
 CREATE TABLE IF NOT EXISTS RESERVATION
 (
     id          bigint not null auto_increment,
-    date        date,
-    time        time,
+    date     date,
+    time     time,
     name        varchar(20),
-    theme_name  varchar(20),
-    theme_desc  varchar(255),
-    theme_price int,
+    theme_id bigint not null,
     primary key (id)
-);
+    );
+
+CREATE TABLE IF NOT EXISTS theme
+(
+    id    bigint not null auto_increment,
+    name  varchar(20),
+    desc  varchar(255),
+    price int,
+    primary key (id)
+    );


### PR DESCRIPTION
안녕하세요! 제출이 늦었습니다. 이번 미션은 테마를 예약 테이블에서 분리, 테마 관리 기능 콘솔에 추가, 테마 관리 API 생성 이렇게 3가지 작업이 있었습니다. 작업하며 추가된 내용(API 명세, 파일 구조)는 README에 업데이트 했습니다!

저번에 피드백 주신대로 이번에는 커밋을 기능별로 더 많이 해보려고 노력했습니다! 커밋 메시지에도 제가 한 작업을 적었는데 다시한번 기술해보겠습니다.

- lombok 라이브러리 적용
    - 도메인 객체 생성에 필요한 인자값이 많은 것 같아서 롬복 라이브러리를 사용해 빌드패턴을 적용해봤습니다. 코드를 직접 작성할 수도 있지만 getter, equals등 메서드를 어노테이션으로 간단히 만들 수 있어서 좋았던 것 같습니다. 다만 빌드패턴을 사용하니 객체 생성할 때 어떤 값을 넣는 지는 명확해졌는데 코드 길이가 더 길어져서 파일이 깔끔해지지 않는 단점이 있는 것 같다고 느꼈습니다.
- Service에 Transactional 어노테이션 붙이기
    - 서비스 클래스에는 Transactional을 붙여서 서비스의 각 일련의 작업을 트랜잭션으로 만들었습니다. DB의 조회만 필요한 작업은 readonly 값을 추가했습니다.
- 검증로직 Repository → Service 이동
    - 중복 예약 추가와 같은 예외 상황에서 예외 발생을 Repository에서 했는데 Service에서 하도록 구조를 변경했습니다. Repository는 DB 접근에만 집중하고, Service에서 비즈니스 관련 예외를 처리하기 위해 이와 같이 변경했습니다. 다만 Theme 삭제과정에서 해당 Theme으로 Reservation이 존재하면 예외처리를 해야하는 부분이 있는데, 이는 참조무결성 관련 예외이기 때문에 Repository에서 처리하도록 했습니다.
- Repository의 create 메서드의 이름 save로 변경
    - DB에 저장할 때는 create보다는 save의 의미가 더 맞는 것 같아서 이름을 변경했습니다.
- Dto 사용
    - 저번에 실무에서 DTO가 많이 사용된다고 말씀해주셔서 사용해봤습니다! 각 엔터티에 대해 Request와 Response를  만들었습니다. 변환은 서비스 계층에서 수행했습니다. 어디서 변환을 수행해야하는 지 고민이 좀 있었는데 Service에서 많이 수행하는 것 같아서 Service에서 변환을 수행했습니다! 또 각 도메인에서는 DTO의 존재를 모르게 하는 것이 좋을 것 같아서 dto 클래스에 entity로 변환하는 메서드(from / to)를 추가했습니다. 또, ReservationResponse는 해당 예약 테마의 모든 정보(이름, 상세정보, 가격)을 모두 가지고 있어야 해서 Reservation 엔터티에 더해 추가 정보를 가지고 있도록 했습니다.
- Service 계층 테스트 추가
    - Service에서 예외가 발생하는 상황에 대한 로직을 테스트하기 위해 Service 계층에 테스트를 추가했습니다. 단순히 Repository의 메서드를 통해 값을 Controller로 전달하는 성격의 메서드(ex. delete)는 테스트하지 않았습니다.
    
테스트 부분에서는 느낀 것이 테이블이 추가되면서 기존에 있던 테스트의 많은 코드가 바뀌어서 리팩터링 내성이 중요하겠다고 느꼈습니다. 더 좋은 테스트를 만드는 방법에 대한 학습도 중요하겠다고 생각했습니다.

+) 1차 리뷰받은 것에 대해 수정한 부분은 [링크](https://github.com/next-step/spring-roomesacpe-reservation-kakao/pull/34#pullrequestreview-1243806290)에 코멘트 달아놨습니다! 참고부탁드립니다!!